### PR TITLE
Remove duplicate label storage init

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,6 @@
   <script src="js/range_rings/range_ring_config.js"></script>
 
   <!-- Label Scripts -->
-  <script src="js/labels/label_storage.js"></script>
   <script src="js/labels/label_controller.js"></script>
   
   <!-- Controller Scripts -->


### PR DESCRIPTION
## Summary
- remove the redundant `label_storage.js` reference so labels are initialized only once

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/walt/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68423ca81608832a941579c5c4ab33f8