### PR TITLE
Move Eruda scripts inside head

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,14 +2,13 @@
 <!DOCTYPE html>
 <html lang="en">
 
-<!-- Eruda for debugging -->
-<script src="libs/eruda/eruda.min.js"></script>
-<script>
-  // Initialize Eruda for debugging
-  eruda.init();
-</script>
-
 <head>
+  <!-- Eruda for debugging -->
+  <script src="libs/eruda/eruda.min.js"></script>
+  <script>
+    // Initialize Eruda for debugging
+    eruda.init();
+  </script>
   <!-- Metadata -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Summary
- relocate the Eruda `<script>` tags from the top of `index.html`
  to inside the `<head>` section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68434085e830832aa792f6cdaa29bc7a