### PR TITLE
Fix export laydown button

### DIFF
--- a/js/export_laydown.js
+++ b/js/export_laydown.js
@@ -69,11 +69,15 @@ var LaydownExporter = (function() {
         var afsimPlatformData = convertPlatformData(PlatformModel.getPlatformData());
         var afsimPlatformDataStr = JSON.stringify(afsimPlatformData);
 
+        // Determine a base href so relative paths work in the new window
+        var baseHref = window.location.href.substring(0, window.location.href.lastIndexOf('/') + 1);
+
         // Construct HTML containing CodeMirror editors
         var htmlContent = `
         <!DOCTYPE html>
         <html lang="en">
         <head>
+            <base href="${baseHref}">
             <meta charset="UTF-8">
             <title>Platform Laydown Editor</title>
             <link rel="stylesheet" href="libs/codemirror/lib/codemirror.css">


### PR DESCRIPTION
## Summary
- fix export page paths by injecting base URL

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68473316b708832a93aa15bee3fa77c9