### PR TITLE
Simplify laydown export page

### DIFF
--- a/export_laydown.html
+++ b/export_laydown.html
@@ -2,60 +2,133 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Platform Laydown Editor</title>
-  <link rel="stylesheet" href="libs/codemirror/lib/codemirror.css">
-  <link rel="stylesheet" href="libs/codemirror/theme/moxer.css">
+  <title>Export Laydown</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
-    html, body { height: 100%; width: 100%; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f8f9fa; color: #333; }
-    body { display: flex; flex-direction: column; }
-    h1 { text-align: center; padding: 20px 0; background-color: #6c757d; color: #fff; font-size: 2em; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin-bottom: 10px; }
-    .editor-container { flex: 1; display: flex; flex-direction: row; padding: 10px 20px; gap: 20px; }
-    .editor-wrapper { flex: 1; display: flex; flex-direction: column; background-color: #fff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); padding: 15px; position: relative; }
-    .editor-label { font-weight: 600; margin-bottom: 10px; color: #0d0d0d; font-size: 1.1em; }
-    .copy-button { position: absolute; top: 15px; right: 15px; padding: 6px 12px; background-color: #6c757d; color: #fff; border: none; border-radius: 4px; cursor: pointer; }
-    .copy-button:hover { background-color: #5a6268; }
-    .CodeMirror { height: 100%; border: 1px solid #ddd; border-radius: 4px; }
+    html, body {
+      height: 100%;
+      width: 100%;
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      background-color: #f8f9fa;
+      color: #333;
+    }
+    body {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+    }
+    .container {
+      width: 100%;
+      max-width: 640px;
+      background-color: #fff;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
+      padding: 32px;
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+    h1 {
+      font-size: 1.75rem;
+      text-align: center;
+      color: #1f2937;
+    }
+    .intro {
+      text-align: center;
+      font-size: 1rem;
+      color: #4b5563;
+    }
+    .button-grid {
+      display: grid;
+      gap: 16px;
+    }
+    @media (min-width: 640px) {
+      .button-grid {
+        grid-template-columns: 1fr 1fr;
+      }
+    }
+    button {
+      padding: 16px;
+      border: none;
+      border-radius: 8px;
+      background-color: #4f46e5;
+      color: #fff;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background-color 0.2s ease, transform 0.2s ease;
+    }
+    button:hover {
+      background-color: #4338ca;
+      transform: translateY(-1px);
+    }
+    button:active {
+      transform: translateY(0);
+    }
+    button:disabled {
+      background-color: #d1d5db;
+      color: #6b7280;
+      cursor: not-allowed;
+      transform: none;
+    }
   </style>
 </head>
 <body>
-  <h1>Platform Laydown Editor</h1>
-  <div class="editor-container">
-    <div class="editor-wrapper">
-      <div class="editor-label">Platform Data</div>
-      <button class="copy-button" data-editor="left">Copy</button>
-      <textarea id="editorLeft"></textarea>
+  <main class="container">
+    <h1>Export Laydown</h1>
+    <p class="intro">Copy the current laydown datasets in a single click.</p>
+    <div class="button-grid">
+      <button id="copy-platforms">Copy platforms to clipboard</button>
+      <button id="copy-weapons">Copy weapons to clipboard</button>
+      <button id="copy-sensors">Copy sensors to clipboard</button>
+      <button id="copy-labels">Copy labels to clipboard</button>
     </div>
-    <div class="editor-wrapper">
-      <div class="editor-label">AFSIM Platform Data</div>
-      <button class="copy-button" data-editor="right">Copy</button>
-      <textarea id="editorRight"></textarea>
-    </div>
-  </div>
-
-  <script src="libs/codemirror/lib/codemirror.js"></script>
-  <script src="libs/codemirror/mode/javascript/javascript.js"></script>
+  </main>
   <script>
-    function setupEditors() {
-      var editorLeft = CodeMirror.fromTextArea(document.getElementById('editorLeft'), { lineNumbers: true, mode: 'javascript', theme: 'moxer' });
-      var editorRight = CodeMirror.fromTextArea(document.getElementById('editorRight'), { lineNumbers: true, mode: 'javascript', theme: 'moxer' });
-      var platData = sessionStorage.getItem('laydownData') || '';
-      var afsimData = sessionStorage.getItem('afsimLaydownData') || '';
-      if (platData) editorLeft.setValue('"use strict";\nvar PLATFORM_DATA = ' + platData + ';');
-      if (afsimData) editorRight.setValue(afsimData);
-      document.querySelectorAll('.copy-button').forEach(function(btn) {
-        btn.addEventListener('click', function() {
-          var val = (this.getAttribute('data-editor') === 'left') ? editorLeft.getValue() : editorRight.getValue();
-          navigator.clipboard.writeText(val).then(() => {
-            var original = this.textContent;
-            this.textContent = 'Copied!';
-            this.disabled = true;
-            setTimeout(() => { this.textContent = original; this.disabled = false; }, 2000);
-          }).catch(() => alert('Failed to copy text. Please try manually.'));
+    (function() {
+      const buttonConfigs = [
+        { id: 'copy-platforms', storageKey: 'platformLaydownData' },
+        { id: 'copy-weapons', storageKey: 'weaponLaydownData' },
+        { id: 'copy-sensors', storageKey: 'sensorLaydownData' },
+        { id: 'copy-labels', storageKey: 'labelLaydownData' }
+      ];
+
+      function copyData(button, storageKey) {
+        const data = sessionStorage.getItem(storageKey);
+        if (!data) {
+          alert('No data available to copy. Please return to the map and try exporting again.');
+          return;
+        }
+
+        navigator.clipboard.writeText(data).then(() => {
+          const originalText = button.textContent;
+          button.textContent = 'Copied!';
+          button.disabled = true;
+          setTimeout(() => {
+            button.textContent = originalText;
+            button.disabled = false;
+          }, 2000);
+        }).catch(() => {
+          alert('Failed to copy text. Please try again.');
         });
-      });
-    }
-    window.addEventListener('DOMContentLoaded', setupEditors);
+      }
+
+      function setupButtons() {
+        buttonConfigs.forEach(config => {
+          const button = document.getElementById(config.id);
+          if (!button) {
+            return;
+          }
+
+          button.addEventListener('click', function() {
+            copyData(button, config.storageKey);
+          });
+        });
+      }
+
+      window.addEventListener('DOMContentLoaded', setupButtons);
+    })();
   </script>
 </body>
 </html>

--- a/js/export_laydown.js
+++ b/js/export_laydown.js
@@ -1,76 +1,20 @@
 // export_laydown.js
 var LaydownExporter = (function() {
-    /**
-     * Converts platform data objects to formatted platform strings for AFSIM.
-     * @param {Array} platformDataArr Array of platform objects.
-     * @returns {Array} Array of formatted platform strings.
-     */
-    function convertPlatformData(platformDataArr) {
-        const newArray = [];
-        platformDataArr.forEach(platform => {
-            let platformStr = `platform ${platform.platform_name} WSF_PLATFORM\n`;
-            platformStr += `\tside ${platform.side}\n`;
-            platformStr += `\taux_data\n`;
-            platformStr += `\t\tstring GROUP = "${platform.group}"\n`;
-
-            // Use only the first subgroup if available
-            if (Array.isArray(platform.subgroups) && platform.subgroups.length > 0) {
-                const subgroup = platform.subgroups[0];
-                platformStr += `\t\tstring SUBGROUP = "${subgroup}"\n`;
-            }
-            platformStr += `\tend_aux_data\n`;
-
-            // Format position with latitude and longitude suffixes
-            let lat = parseFloat(platform.latitude);
-            let lon = parseFloat(platform.longitude);
-            const latSuffix = lat < 0 ? 's' : 'n';
-            const lonSuffix = lon < 0 ? 'w' : 'e';
-            const formattedLat = Math.abs(lat).toFixed(6);
-            const formattedLon = Math.abs(lon).toFixed(5);
-            platformStr += `\tposition ${formattedLat}${latSuffix} ${formattedLon}${lonSuffix}\n`;
-
-            // Add altitude
-            const altitude = parseFloat(platform.altitude);
-            platformStr += `\taltitude ${altitude} m\n`;
-
-            // If altitude is 0, add category and icon
-            if (altitude === 0) {
-                platformStr += `\tcategory surface\n`;
-                platformStr += `\ticon ship\n`;
-            }
-
-            // Add Weapons if any
-            if (Array.isArray(platform.weapons) && platform.weapons.length > 0) {
-                platformStr += `\t// WEAPONS\n`;
-                platform.weapons.forEach(weapon => {
-                    platformStr += `\tadd weapon ${weapon.name} WSF_EXPLICIT_WEAPON launched_platform_type NULL_WEAP quantity ${weapon.quantity} end_weapon\n`;
-                });
-            }
-
-            // Add Sensors if any
-            if (Array.isArray(platform.sensors) && platform.sensors.length > 0) {
-                platformStr += `\t// SENSORS\n`;
-                platform.sensors.forEach(sensor => {
-                    platformStr += `\tadd sensor ${sensor} NULL_SENSOR end_sensor\n`;
-                });
-            }
-
-            platformStr += `end_platform`;
-            newArray.push(platformStr);
-        });
-        return newArray;
+    function formatData(variableName, dataString) {
+        return `var ${variableName} = ${dataString};`;
     }
 
-    // Export platform laydown to a CodeMirror editor window
     function exportLaydown() {
         var platformDataStr = PlatformModel.exportData();
-        var afsimPlatformData = convertPlatformData(PlatformModel.getPlatformData());
+        var weaponDataStr = WeaponStorage.exportData();
+        var sensorDataStr = SensorStorage.exportData();
+        var labelDataStr = JSON.stringify(LabelStorage.getLabelData(), null, 2);
 
-        // Store data in sessionStorage for the export page
-        sessionStorage.setItem('laydownData', platformDataStr);
-        sessionStorage.setItem('afsimLaydownData', JSON.stringify(afsimPlatformData));
+        sessionStorage.setItem('platformLaydownData', formatData('PLATFORM_DATA', platformDataStr));
+        sessionStorage.setItem('weaponLaydownData', formatData('WEAPON_DATA', weaponDataStr));
+        sessionStorage.setItem('sensorLaydownData', formatData('SENSOR_DATA', sensorDataStr));
+        sessionStorage.setItem('labelLaydownData', formatData('LABEL_DATA', labelDataStr));
 
-        // Open the static export page
         window.open('export_laydown.html', '_blank');
     }
 


### PR DESCRIPTION
## Summary
- replace the export laydown editors with a streamlined layout containing four copy buttons
- persist formatted platform, weapon, sensor, and label datasets in session storage for clipboard export
- implement clipboard handlers that provide quick feedback when copying data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d43b57d1d8832ab3421bce8670a606