### PR TITLE
Implement weapon deletion across dependent data

### DIFF
--- a/js/weapons/weapon_config.js
+++ b/js/weapons/weapon_config.js
@@ -105,8 +105,7 @@ var WeaponConfig = (function() {
         // Handle delete weapon
         $('.delete-weapon').off('click').on('click', function() {
             var index = $(this).data('index');
-            //deleteWeaponFromStorage(index);
-            createWeaponConfigDialog();
+            handleWeaponDeletion(index);
         });
 
         // Handle add weapon
@@ -197,12 +196,42 @@ var WeaponConfig = (function() {
         }
     }
 
+    function handleWeaponDeletion(index) {
+        var weaponData = WeaponStorage.getWeaponData();
+
+        if (!Array.isArray(weaponData) || index < 0 || index >= weaponData.length) {
+            return;
+        }
+
+        var weaponEntry = weaponData[index];
+        var weaponName = weaponEntry.weapon_name;
+
+        if (!weaponName) {
+            return;
+        }
+
+        var confirmed = confirm('Are you sure you want to delete the weapon "' + weaponName + '"?');
+        if (!confirmed) {
+            return;
+        }
+
+        removeWeaponFromPlatforms(weaponName);
+        deleteWeaponFromStorage(index);
+
+        RangeRingStorage.init();
+        RangeRingLogic.drawRangeRings();
+        View.updateAll();
+
+        createWeaponConfigDialog();
+    }
+
     // Function to delete weapon from storage
     function deleteWeaponFromStorage(index) {
         var weaponData = WeaponStorage.getWeaponData();
         if (index >= 0 && index < weaponData.length) {
-            weaponData.splice(index, 1);
+            return weaponData.splice(index, 1)[0];
         }
+        return null;
     }
 
     // Function to check if weapon name is unique
@@ -219,7 +248,7 @@ var WeaponConfig = (function() {
     // Helper function to change weapon names in platformData after they have been modified
     function updatePlatformWeaponReferences(oldName, newName) {
         var platformData = PlatformModel.getPlatformData();
-    
+
         platformData.forEach(platform => {
             // Find and replace old weapon name with the new one
             platform.weapons.forEach(weapon => {
@@ -227,6 +256,22 @@ var WeaponConfig = (function() {
                     weapon.name = newName;
                 }
             });
+        });
+    }
+
+    function removeWeaponFromPlatforms(weaponName) {
+        var platformData = PlatformModel.getPlatformData();
+
+        platformData.forEach(platform => {
+            if (!Array.isArray(platform.weapons)) {
+                return;
+            }
+
+            for (var i = platform.weapons.length - 1; i >= 0; i--) {
+                if (platform.weapons[i].name === weaponName) {
+                    platform.weapons.splice(i, 1);
+                }
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- wire the weapon configuration delete action to remove the selected entry with confirmation
- clean up platform loadouts, range-ring data, and dependent views after weapon removal
- redraw range overlays so deleted weapons no longer appear on the map

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d535005398832a85c4ae0520e6fc4a