### PR TITLE
Sort range ring rendering by size

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -43,3 +43,13 @@ body {
     border-radius: 3px;
     font-size: 12px;
 }
+
+.range-ring-tooltip {
+    background: rgba(0, 0, 0, 0.75);
+    color: #fff;
+    border-radius: 4px;
+    padding: 4px 6px;
+    font-size: 11px;
+    line-height: 1.3;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}

--- a/js/range_rings/range_ring_logic.js
+++ b/js/range_rings/range_ring_logic.js
@@ -25,9 +25,14 @@ var RangeRingLogic = (function() {
     }, {});
 
     // Iterate through each range ring in the array
-    rangeRings.forEach(function(rangeRing) {
-      // Only render if toggled is set to 1
-      if (rangeRing.toggled === 1) {
+    rangeRings
+      .filter(function(rangeRing) {
+        return rangeRing.toggled === 1;
+      })
+      .sort(function(a, b) {
+        return b.range_val - a.range_val;
+      })
+      .forEach(function(rangeRing) {
         // Determine the side and corresponding color
         var side = platformSideLookup[rangeRing.platform_name];
         var color = side === 'blue' ? 'blue' : (side === 'red' ? 'red' : 'gray');
@@ -44,8 +49,7 @@ var RangeRingLogic = (function() {
         // Add the circle to the map and keep track of it
         circle.addTo(map);
         rangeRingLayers.push(circle);
-      }
-    });
+      });
   }
 
   // New function to draw a range ring around a specific platform by name
@@ -58,9 +62,13 @@ var RangeRingLogic = (function() {
     }, {});
   
     // Filter range rings for the specified platform that are toggled
-    var matchingRangeRings = rangeRings.filter(function(ring) {
-      return ring.platform_name === platformName;
-    });
+    var matchingRangeRings = rangeRings
+      .filter(function(ring) {
+        return ring.platform_name === platformName;
+      })
+      .sort(function(a, b) {
+        return b.range_val - a.range_val;
+      });
   
     // Draw each matching range ring
     matchingRangeRings.forEach(function(rangeRing) {

--- a/js/range_rings/range_ring_logic.js
+++ b/js/range_rings/range_ring_logic.js
@@ -46,6 +46,25 @@ var RangeRingLogic = (function() {
           fillOpacity: 0.01 // Inner fill opacity
         });
 
+        var rangeValue = typeof rangeRing.range_val === 'number'
+          ? rangeRing.range_val
+          : parseFloat(rangeRing.range_val);
+        var formattedRange = isFinite(rangeValue)
+          ? rangeValue.toLocaleString()
+          : 'Unknown';
+
+        var tooltipContent = [
+          rangeRing.system_name || 'Unknown System',
+          rangeRing.platform_name || 'Unknown Platform',
+          formattedRange + ' m'
+        ].join('<br>');
+
+        circle.bindTooltip(tooltipContent, {
+          direction: 'top',
+          sticky: true,
+          className: 'range-ring-tooltip'
+        });
+
         // Add the circle to the map and keep track of it
         circle.addTo(map);
         rangeRingLayers.push(circle);
@@ -84,6 +103,25 @@ var RangeRingLogic = (function() {
         fillOpacity: 0.01
       });
   
+      var rangeValue = typeof rangeRing.range_val === 'number'
+        ? rangeRing.range_val
+        : parseFloat(rangeRing.range_val);
+      var formattedRange = isFinite(rangeValue)
+        ? rangeValue.toLocaleString()
+        : 'Unknown';
+
+      var tooltipContent = [
+        rangeRing.system_name || 'Unknown System',
+        rangeRing.platform_name || 'Unknown Platform',
+        formattedRange + ' m'
+      ].join('<br>');
+
+      circle.bindTooltip(tooltipContent, {
+        direction: 'top',
+        sticky: true,
+        className: 'range-ring-tooltip'
+      });
+
       // Add the circle to the map and keep track of it
       circle.addTo(map);
       rangeRingLayers.push(circle);


### PR DESCRIPTION
## Summary
- sort toggled range rings by descending radius before drawing to keep smaller circles on top
- apply the same size-based ordering to platform preview renders

## Testing
- not run (manual UI verification required)


------
https://chatgpt.com/codex/tasks/task_e_68d69052f4b0832a9be189a58936dabe