### PR TITLE
Add dynamic map tools menu

### DIFF
--- a/css/map-tools.css
+++ b/css/map-tools.css
@@ -74,7 +74,28 @@
     background-image: url('../images/tt-symbol-24px.png');
 }
 
+.map-tools__tool-icon--range-ring-opacity {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    font-size: 16px;
+    color: #1a1a1a;
+}
+
 .map-tools__tool--active {
     border-color: chartreuse !important;
     box-shadow: 0 0 0 1px rgba(127, 255, 0, 0.6);
+}
+
+.range-ring-opacity-dialog__input {
+    width: 100%;
+    box-sizing: border-box;
+    margin-top: 4px;
+}
+
+.range-ring-opacity-dialog__hint {
+    margin-top: 8px;
+    font-size: 0.85em;
+    color: #555;
 }

--- a/css/map-tools.css
+++ b/css/map-tools.css
@@ -1,0 +1,80 @@
+/* map-tools.css */
+.map-tools {
+    position: absolute;
+    top: 132px;
+    left: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    z-index: 1000;
+}
+
+.map-tools__toggle,
+.map-tools__tool {
+    width: 40px;
+    height: 40px;
+    border: 2px solid rgba(128, 128, 128, 0.5);
+    border-radius: 5px;
+    background-color: #fff;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+    transition: border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.map-tools__toggle:hover,
+.map-tools__tool:hover {
+    border-color: rgba(70, 130, 180, 0.8);
+}
+
+.map-tools__toggle:focus-visible,
+.map-tools__tool:focus-visible {
+    outline: 2px solid #2684ff;
+    outline-offset: 2px;
+}
+
+.map-tools__toggle-icon {
+    font-size: 16px;
+    line-height: 1;
+}
+
+.map-tools__tray {
+    display: flex;
+    flex-direction: column;
+    gap: var(--map-tools-gap, 8px);
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-4px);
+    transition: max-height 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
+}
+
+.map-tools--open .map-tools__tray {
+    max-height: var(--map-tools-tray-size, 0px);
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+}
+
+.map-tools__tool-icon {
+    width: 24px;
+    height: 24px;
+    display: block;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+}
+
+.map-tools__tool-icon--label {
+    background-image: url('../images/tt-symbol-24px.png');
+}
+
+.map-tools__tool--active {
+    border-color: chartreuse !important;
+    box-shadow: 0 0 0 1px rgba(127, 255, 0, 0.6);
+}

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
   <!---------------------------------------------->
   <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="css/walt-menu-styles.css">
+  <link rel="stylesheet" href="css/map-tools.css">
   <link rel="stylesheet" href="js/labels/label-styles.css">
 </head>
 
@@ -54,8 +55,6 @@
     <button id="clearRangeRingsButton">
       Clear Range Rings
     </button>
-    <!-- Button for adding text labels to the map -->
-    <button id="addTextLabelButton"></button>
   </div>
 
   <!------------------------------------------->
@@ -132,6 +131,7 @@
   <script src="js/distance_storage.js"></script>
   <script src="js/labels/label_storage.js"></script>
   <script src="js/export_laydown.js"></script>
+  <script src="js/map_tools/map_tools_menu.js"></script>
   <script src="js/view.js"></script>
 
 

--- a/index.html
+++ b/index.html
@@ -138,6 +138,7 @@
   <!-- Range Ring Scripts -->
   <script src="js/range_rings/range_ring_storage.js"></script>
   <script src="js/range_rings/range_ring_logic.js"></script>
+  <script src="js/range_rings/range_ring_opacity_tool.js"></script>
   <script src="js/range_rings/range_ring_config.js"></script>
 
   <!-- Label Scripts -->

--- a/js/labels/label-styles.css
+++ b/js/labels/label-styles.css
@@ -1,41 +1,16 @@
 /* label-styles.css */
-#addTextLabelButton {
-    position: absolute;
-    top: 132px;
-    left: 10px;
-    width: 38.2px; 
-    height: 38.2px; 
-    background-color: white;
-    border: 2px solid rgba(128, 128, 128, 0.5); 
-    border-radius: 5px; /* Rounded corners */
-    z-index: 1000; 
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0;
-    background-repeat: no-repeat;
-    background-position: center;
-    background-image: url("../../images/tt-symbol-24px.png");
-  }
-
-  #addTextLabelButton-clicked {
-    border-color:chartreuse !important;
-  }
-
 .label-icon {
-  pointer-events: auto; /* Allow click events */
+  pointer-events: auto;
   cursor: pointer;
   z-index: 9999;
 }
 
 .custom-label {
-  white-space: nowrap; 
+  white-space: nowrap;
   background-color: rgba(255, 255, 255, 0.8);
   padding: 2px 4px;
   border-radius: 3px;
   border: 1px solid #ccc;
-  display: inline-block; 
-  overflow: visible; 
+  display: inline-block;
+  overflow: visible;
 }
-  

--- a/js/labels/label_controller.js
+++ b/js/labels/label_controller.js
@@ -1,8 +1,9 @@
 // label_controller.js
 var LabelController = (function(LabelStorage) {
-    var map; 
-    var labelLayerGroup; 
-    var addLabelMode = false; 
+    var map;
+    var labelLayerGroup;
+    var addLabelMode = false;
+    var LABEL_TOOL_ID = 'add-text-label';
 
     function init() {
         map = View.getMap();
@@ -15,6 +16,19 @@ var LabelController = (function(LabelStorage) {
         renderLabels();
 
         map.on('click', onMapClick);
+
+        registerMapTool();
+    }
+
+    function registerMapTool() {
+        MapToolsMenu.registerTool({
+            id: LABEL_TOOL_ID,
+            label: 'Add text label',
+            iconClass: 'map-tools__tool-icon--label',
+            onClick: function() {
+                createLabel();
+            }
+        });
     }
 
     function renderLabels() {
@@ -95,10 +109,10 @@ var LabelController = (function(LabelStorage) {
         addLabelMode = !addLabelMode;
         if (addLabelMode) {
             map.getContainer().style.cursor = 'crosshair';
-            document.getElementById('addTextLabelButton').classList.add('addTextLabelButton-clicked');
+            MapToolsMenu.setToolActive(LABEL_TOOL_ID, true);
         } else {
             map.getContainer().style.cursor = '';
-            document.getElementById('addTextLabelButton').classList.remove('addTextLabelButton-clicked');
+            MapToolsMenu.setToolActive(LABEL_TOOL_ID, false);
         }
     }
 

--- a/js/map_tools/map_tools_menu.js
+++ b/js/map_tools/map_tools_menu.js
@@ -1,0 +1,196 @@
+// map_tools_menu.js
+var MapToolsMenu = (function() {
+    var state = {
+        root: null,
+        tray: null,
+        toggleButton: null,
+        toggleIcon: null,
+        mapContainer: null,
+        isOpen: false,
+        tools: new Map(),
+        itemHeight: 44,
+        itemGap: 8
+    };
+
+    function init(options) {
+        options = options || {};
+
+        if (state.root) {
+            return state.root;
+        }
+
+        state.mapContainer = resolveContainer(options);
+        if (!state.mapContainer) {
+            throw new Error('MapToolsMenu: unable to locate map container.');
+        }
+
+        state.itemHeight = options.itemHeight || state.itemHeight;
+        state.itemGap = options.itemGap || state.itemGap;
+
+        createMenu(options);
+        return state.root;
+    }
+
+    function resolveContainer(options) {
+        if (options.container) {
+            return options.container;
+        }
+        if (options.map && options.map.getContainer) {
+            return options.map.getContainer();
+        }
+        var containerId = options.containerId || 'map';
+        return document.getElementById(containerId);
+    }
+
+    function createMenu(options) {
+        state.root = document.createElement('div');
+        state.root.className = 'map-tools';
+
+        state.toggleButton = document.createElement('button');
+        state.toggleButton.type = 'button';
+        state.toggleButton.className = 'map-tools__toggle';
+        state.toggleButton.setAttribute('aria-expanded', 'false');
+        state.toggleButton.setAttribute('aria-label', options.toggleLabel || 'Toggle map tools');
+
+        state.toggleIcon = document.createElement('span');
+        state.toggleIcon.className = 'map-tools__toggle-icon';
+        state.toggleIcon.setAttribute('aria-hidden', 'true');
+        state.toggleIcon.textContent = '\u25BC';
+
+        state.toggleButton.appendChild(state.toggleIcon);
+        state.toggleButton.addEventListener('click', function(event) {
+            event.preventDefault();
+            event.stopPropagation();
+            toggle();
+        });
+
+        state.tray = document.createElement('div');
+        state.tray.className = 'map-tools__tray';
+        state.tray.style.setProperty('--map-tools-gap', state.itemGap + 'px');
+
+        state.root.appendChild(state.toggleButton);
+        state.root.appendChild(state.tray);
+
+        state.mapContainer.appendChild(state.root);
+
+        if (options.tools && Array.isArray(options.tools)) {
+            options.tools.forEach(registerTool);
+        }
+    }
+
+    function toggle(forceState) {
+        if (typeof forceState === 'boolean') {
+            state.isOpen = forceState;
+        } else {
+            state.isOpen = !state.isOpen;
+        }
+
+        if (!state.root) {
+            return;
+        }
+
+        if (state.isOpen) {
+            state.root.classList.add('map-tools--open');
+            state.toggleButton.setAttribute('aria-expanded', 'true');
+            state.toggleIcon.textContent = '\u25B2';
+        } else {
+            state.root.classList.remove('map-tools--open');
+            state.toggleButton.setAttribute('aria-expanded', 'false');
+            state.toggleIcon.textContent = '\u25BC';
+        }
+    }
+
+    function ensureInitialized() {
+        if (!state.root) {
+            init({});
+        }
+    }
+
+    function registerTool(toolConfig) {
+        ensureInitialized();
+
+        if (!toolConfig || !toolConfig.id) {
+            throw new Error('MapToolsMenu.registerTool requires a unique id.');
+        }
+
+        if (state.tools.has(toolConfig.id)) {
+            throw new Error('MapToolsMenu: tool with id "' + toolConfig.id + '" already exists.');
+        }
+
+        var button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'map-tools__tool';
+        button.setAttribute('data-tool-id', toolConfig.id);
+        button.setAttribute('aria-pressed', 'false');
+
+        if (toolConfig.label) {
+            button.setAttribute('aria-label', toolConfig.label);
+            button.title = toolConfig.label;
+        }
+
+        var icon = document.createElement('span');
+        icon.className = 'map-tools__tool-icon';
+        if (toolConfig.iconClass) {
+            icon.classList.add(toolConfig.iconClass);
+        }
+        if (toolConfig.iconUrl) {
+            icon.style.backgroundImage = 'url(' + toolConfig.iconUrl + ')';
+        }
+        if (toolConfig.content) {
+            icon.textContent = toolConfig.content;
+        }
+        button.appendChild(icon);
+
+        button.addEventListener('click', function(event) {
+            event.preventDefault();
+            event.stopPropagation();
+            if (typeof toolConfig.onClick === 'function') {
+                toolConfig.onClick(event, button);
+            }
+        });
+
+        state.tray.appendChild(button);
+        state.tools.set(toolConfig.id, {
+            config: toolConfig,
+            element: button
+        });
+
+        updateTraySize();
+        return button;
+    }
+
+    function updateTraySize() {
+        var count = state.tray.children.length;
+        if (!count) {
+            toggle(false);
+        }
+        var totalHeight = 0;
+        if (count > 0) {
+            totalHeight = (count * state.itemHeight) + ((count - 1) * state.itemGap);
+        }
+        state.tray.style.setProperty('--map-tools-tray-size', totalHeight + 'px');
+    }
+
+    function setToolActive(id, isActive) {
+        var entry = state.tools.get(id);
+        if (!entry) {
+            return;
+        }
+        var active = !!isActive;
+        entry.element.classList.toggle('map-tools__tool--active', active);
+        entry.element.setAttribute('aria-pressed', active ? 'true' : 'false');
+    }
+
+    function getToolElement(id) {
+        var entry = state.tools.get(id);
+        return entry ? entry.element : null;
+    }
+
+    return {
+        init: init,
+        toggle: toggle,
+        registerTool: registerTool,
+        setToolActive: setToolActive,
+        getToolElement: getToolElement
+    };
+})();

--- a/js/range_rings/range_ring_logic.js
+++ b/js/range_rings/range_ring_logic.js
@@ -3,6 +3,9 @@ var RangeRingLogic = (function() {
   // Array to keep track of range ring layers added to the map
   var rangeRingLayers = [];
 
+  var DEFAULT_RING_OPACITY = 0.2;
+  var rangeRingOpacity = DEFAULT_RING_OPACITY;
+
   // Function to draw range rings on the map
   function drawRangeRings() {
 
@@ -42,7 +45,7 @@ var RangeRingLogic = (function() {
           radius: rangeRing.range_val, // radius in meters
           color: color,
           weight: 0.5,
-          opacity: 0.2, // Set the line opacity here
+          opacity: rangeRingOpacity, // Set the line opacity here
           fillOpacity: 0.01 // Inner fill opacity
         });
 
@@ -99,7 +102,7 @@ var RangeRingLogic = (function() {
         radius: rangeRing.range_val,
         color: color,
         weight: 0.5,
-        opacity: 0.2,
+        opacity: rangeRingOpacity,
         fillOpacity: 0.01
       });
   
@@ -139,11 +142,32 @@ var RangeRingLogic = (function() {
     rangeRingLayers = [];
   }
 
+  function setRangeRingOpacity(opacity) {
+    var parsed = parseFloat(opacity);
+    if (!isFinite(parsed)) {
+      return;
+    }
+
+    // Clamp value between 0 and 1
+    parsed = Math.max(0, Math.min(1, parsed));
+    rangeRingOpacity = parsed;
+
+    rangeRingLayers.forEach(function(layer) {
+      layer.setStyle({ opacity: rangeRingOpacity });
+    });
+  }
+
+  function getRangeRingOpacity() {
+    return rangeRingOpacity;
+  }
+
   // Return public functions
   return {
     drawRangeRings: drawRangeRings,
     drawRangeRingForPlatform: drawRangeRingForPlatform,
-    clearRangeRings: clearRangeRings
+    clearRangeRings: clearRangeRings,
+    setRangeRingOpacity: setRangeRingOpacity,
+    getRangeRingOpacity: getRangeRingOpacity
   };
 
 })();

--- a/js/range_rings/range_ring_opacity_tool.js
+++ b/js/range_rings/range_ring_opacity_tool.js
@@ -1,0 +1,75 @@
+// range_ring_opacity_tool.js
+var RangeRingOpacityTool = (function() {
+  var TOOL_ID = 'range-ring-opacity';
+  var dialogInstance = null;
+  var inputElement = null;
+
+  function registerTool() {
+    MapToolsMenu.registerTool({
+      id: TOOL_ID,
+      label: 'Set range ring opacity',
+      iconClass: 'map-tools__tool-icon--range-ring-opacity',
+      content: '\u03B1',
+      onClick: function() {
+        openDialog();
+      }
+    });
+  }
+
+  function ensureDialog() {
+    if (dialogInstance) {
+      return;
+    }
+
+    var dialogContent = [
+      '<div class="range-ring-opacity-dialog" title="Range Ring Opacity">',
+      '  <form>',
+      '    <label for="rangeRingOpacityInput">Opacity (0 - 1):</label>',
+      '    <input type="number" id="rangeRingOpacityInput" name="rangeRingOpacityInput" min="0" max="1" step="0.05" class="range-ring-opacity-dialog__input" />',
+      '    <p class="range-ring-opacity-dialog__hint">All current and future range rings will use this opacity.</p>',
+      '  </form>',
+      '</div>'
+    ].join('');
+
+    dialogInstance = $(dialogContent).dialog({
+      autoOpen: false,
+      modal: true,
+      buttons: {
+        'Save': function() {
+          var value = parseFloat(inputElement.val());
+          if (!isFinite(value)) {
+            alert('Please enter a numeric opacity value between 0 and 1.');
+            return;
+          }
+
+          if (value < 0 || value > 1) {
+            alert('Opacity must be between 0 and 1.');
+            return;
+          }
+
+          RangeRingLogic.setRangeRingOpacity(value);
+          $(this).dialog('close');
+        },
+        'Cancel': function() {
+          $(this).dialog('close');
+        }
+      },
+      width: 360
+    });
+
+    inputElement = dialogInstance.find('#rangeRingOpacityInput');
+  }
+
+  function openDialog() {
+    ensureDialog();
+    var currentOpacity = RangeRingLogic.getRangeRingOpacity();
+    inputElement.val(currentOpacity.toFixed(2));
+    dialogInstance.dialog('open');
+  }
+
+  registerTool();
+
+  return {
+    openDialog: openDialog
+  };
+})();

--- a/js/view.js
+++ b/js/view.js
@@ -45,6 +45,9 @@ var View = (function() {
         };
         L.control.ruler(options).addTo(map);
 
+        // Initialize the dynamic map tools menu
+        MapToolsMenu.init({ map: map });
+
         // Create gridlines overlay
         var gridlines = new GridlinesOverlay(map);
         // var gridlines = new GridlinesOverlay(map, {
@@ -124,12 +127,6 @@ var View = (function() {
         // Add an event listener to the 'Display Results' button
         document.getElementById('refreshDataButton').addEventListener('click', updateAll);
 
-        // Add an event listener to the 'Add Text Label' button
-        document.getElementById('addTextLabelButton').addEventListener('click', function(event) {
-            event.preventDefault(); // Prevent default button behavior if any
-            event.stopPropagation(); // Stop the event from bubbling up to the map
-            LabelController.createLabel();
-        });
     }
 
     // Render platforms from platform details


### PR DESCRIPTION
## Summary
- add a reusable MapToolsMenu module that renders a collapsible tool tray and exposes registration helpers for future controls
- style and load the new map tools menu while removing the inline label button markup
- integrate the label controller with the menu so the add-label tool uses shared active-state styling

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68da8117aa64832a92720c6abdd47ccd