### PR TITLE
Add map tool to adjust range ring opacity

### DIFF
--- a/css/map-tools.css
+++ b/css/map-tools.css
@@ -74,7 +74,28 @@
     background-image: url('../images/tt-symbol-24px.png');
 }
 
+.map-tools__tool-icon--range-ring-opacity {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    font-size: 16px;
+    color: #1a1a1a;
+}
+
 .map-tools__tool--active {
     border-color: chartreuse !important;
     box-shadow: 0 0 0 1px rgba(127, 255, 0, 0.6);
+}
+
+.range-ring-opacity-dialog__input {
+    width: 100%;
+    box-sizing: border-box;
+    margin-top: 4px;
+}
+
+.range-ring-opacity-dialog__hint {
+    margin-top: 8px;
+    font-size: 0.85em;
+    color: #555;
 }

--- a/index.html
+++ b/index.html
@@ -138,6 +138,7 @@
   <!-- Range Ring Scripts -->
   <script src="js/range_rings/range_ring_storage.js"></script>
   <script src="js/range_rings/range_ring_logic.js"></script>
+  <script src="js/range_rings/range_ring_opacity_tool.js"></script>
   <script src="js/range_rings/range_ring_config.js"></script>
 
   <!-- Label Scripts -->

--- a/js/range_rings/range_ring_logic.js
+++ b/js/range_rings/range_ring_logic.js
@@ -3,6 +3,9 @@ var RangeRingLogic = (function() {
   // Array to keep track of range ring layers added to the map
   var rangeRingLayers = [];
 
+  var DEFAULT_RING_OPACITY = 0.2;
+  var rangeRingOpacity = DEFAULT_RING_OPACITY;
+
   // Function to draw range rings on the map
   function drawRangeRings() {
 
@@ -42,7 +45,7 @@ var RangeRingLogic = (function() {
           radius: rangeRing.range_val, // radius in meters
           color: color,
           weight: 0.5,
-          opacity: 0.2, // Set the line opacity here
+          opacity: rangeRingOpacity, // Set the line opacity here
           fillOpacity: 0.01 // Inner fill opacity
         });
 
@@ -99,7 +102,7 @@ var RangeRingLogic = (function() {
         radius: rangeRing.range_val,
         color: color,
         weight: 0.5,
-        opacity: 0.2,
+        opacity: rangeRingOpacity,
         fillOpacity: 0.01
       });
   
@@ -139,11 +142,32 @@ var RangeRingLogic = (function() {
     rangeRingLayers = [];
   }
 
+  function setRangeRingOpacity(opacity) {
+    var parsed = parseFloat(opacity);
+    if (!isFinite(parsed)) {
+      return;
+    }
+
+    // Clamp value between 0 and 1
+    parsed = Math.max(0, Math.min(1, parsed));
+    rangeRingOpacity = parsed;
+
+    rangeRingLayers.forEach(function(layer) {
+      layer.setStyle({ opacity: rangeRingOpacity });
+    });
+  }
+
+  function getRangeRingOpacity() {
+    return rangeRingOpacity;
+  }
+
   // Return public functions
   return {
     drawRangeRings: drawRangeRings,
     drawRangeRingForPlatform: drawRangeRingForPlatform,
-    clearRangeRings: clearRangeRings
+    clearRangeRings: clearRangeRings,
+    setRangeRingOpacity: setRangeRingOpacity,
+    getRangeRingOpacity: getRangeRingOpacity
   };
 
 })();

--- a/js/range_rings/range_ring_opacity_tool.js
+++ b/js/range_rings/range_ring_opacity_tool.js
@@ -1,0 +1,75 @@
+// range_ring_opacity_tool.js
+var RangeRingOpacityTool = (function() {
+  var TOOL_ID = 'range-ring-opacity';
+  var dialogInstance = null;
+  var inputElement = null;
+
+  function registerTool() {
+    MapToolsMenu.registerTool({
+      id: TOOL_ID,
+      label: 'Set range ring opacity',
+      iconClass: 'map-tools__tool-icon--range-ring-opacity',
+      content: '\u03B1',
+      onClick: function() {
+        openDialog();
+      }
+    });
+  }
+
+  function ensureDialog() {
+    if (dialogInstance) {
+      return;
+    }
+
+    var dialogContent = [
+      '<div class="range-ring-opacity-dialog" title="Range Ring Opacity">',
+      '  <form>',
+      '    <label for="rangeRingOpacityInput">Opacity (0 - 1):</label>',
+      '    <input type="number" id="rangeRingOpacityInput" name="rangeRingOpacityInput" min="0" max="1" step="0.05" class="range-ring-opacity-dialog__input" />',
+      '    <p class="range-ring-opacity-dialog__hint">All current and future range rings will use this opacity.</p>',
+      '  </form>',
+      '</div>'
+    ].join('');
+
+    dialogInstance = $(dialogContent).dialog({
+      autoOpen: false,
+      modal: true,
+      buttons: {
+        'Save': function() {
+          var value = parseFloat(inputElement.val());
+          if (!isFinite(value)) {
+            alert('Please enter a numeric opacity value between 0 and 1.');
+            return;
+          }
+
+          if (value < 0 || value > 1) {
+            alert('Opacity must be between 0 and 1.');
+            return;
+          }
+
+          RangeRingLogic.setRangeRingOpacity(value);
+          $(this).dialog('close');
+        },
+        'Cancel': function() {
+          $(this).dialog('close');
+        }
+      },
+      width: 360
+    });
+
+    inputElement = dialogInstance.find('#rangeRingOpacityInput');
+  }
+
+  function openDialog() {
+    ensureDialog();
+    var currentOpacity = RangeRingLogic.getRangeRingOpacity();
+    inputElement.val(currentOpacity.toFixed(2));
+    dialogInstance.dialog('open');
+  }
+
+  registerTool();
+
+  return {
+    openDialog: openDialog
+  };
+})();


### PR DESCRIPTION
## Summary
- add a map tools button that opens a dialog to set the shared range ring opacity
- store and reuse the configured opacity for both existing range rings and newly created ones
- style the opacity tool icon and dialog input for clarity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da9291e248832a8fe3ec6afb3062d3