### PR TITLE
Add map tool to control range ring opacity

### DIFF
--- a/js/range_rings/range_ring_logic.js
+++ b/js/range_rings/range_ring_logic.js
@@ -2,6 +2,7 @@ var RangeRingLogic = (function() {
 
   // Array to keep track of range ring layers added to the map
   var rangeRingLayers = [];
+  var RANGE_RING_OPACITY_TOOL_ID = 'range-ring-opacity';
 
   // Function to draw range rings on the map
   function drawRangeRings() {
@@ -42,7 +43,7 @@ var RangeRingLogic = (function() {
           radius: rangeRing.range_val, // radius in meters
           color: color,
           weight: 0.5,
-          opacity: 0.2, // Set the line opacity here
+          opacity: getRangeRingOpacity(rangeRing),
           fillOpacity: 0.01 // Inner fill opacity
         });
 
@@ -71,8 +72,15 @@ var RangeRingLogic = (function() {
       });
   }
 
+  function getRangeRingOpacity(rangeRing) {
+    if (typeof rangeRing.opacity === 'number') {
+      return rangeRing.opacity;
+    }
+    return RangeRingStorage.getOpacity();
+  }
+
   // New function to draw a range ring around a specific platform by name
-  function drawRangeRingForPlatform(platformName, rangeRings, map) {  
+  function drawRangeRingForPlatform(platformName, rangeRings, map) {
     // Get platform data from PlatformModel
     var platformData = PlatformModel.getPlatformData();
     var platformSideLookup = platformData.reduce(function(acc, platform) {
@@ -99,7 +107,7 @@ var RangeRingLogic = (function() {
         radius: rangeRing.range_val,
         color: color,
         weight: 0.5,
-        opacity: 0.2,
+        opacity: getRangeRingOpacity(rangeRing),
         fillOpacity: 0.01
       });
   
@@ -138,6 +146,34 @@ var RangeRingLogic = (function() {
     });
     rangeRingLayers = [];
   }
+
+  function registerOpacityTool() {
+    MapToolsMenu.registerTool({
+      id: RANGE_RING_OPACITY_TOOL_ID,
+      label: 'Set range ring opacity',
+      content: 'Op',
+      onClick: function() {
+        var currentOpacity = RangeRingStorage.getOpacity();
+        var input = window.prompt('Set range ring opacity (0 to 1)', currentOpacity);
+        if (input === null) {
+          return;
+        }
+        var parsedOpacity = parseFloat(input);
+        if (!isFinite(parsedOpacity) || parsedOpacity < 0 || parsedOpacity > 1) {
+          window.alert('Please enter a numeric opacity between 0 and 1.');
+          return;
+        }
+        RangeRingStorage.setOpacity(parsedOpacity);
+        rangeRingLayers.forEach(function(layer) {
+          if (layer && typeof layer.setStyle === 'function') {
+            layer.setStyle({ opacity: parsedOpacity });
+          }
+        });
+      }
+    });
+  }
+
+  registerOpacityTool();
 
   // Return public functions
   return {

--- a/js/range_rings/range_ring_storage.js
+++ b/js/range_rings/range_ring_storage.js
@@ -1,6 +1,7 @@
 // range_rings_storage.js
 var RangeRingStorage = (function() {
     var rangeRings = [];
+    var currentOpacity = 0.2;
 
     // Load initial data from separate data models
     function init() {
@@ -36,7 +37,8 @@ var RangeRingStorage = (function() {
                             range_val: weaponDict[weapon.name].weapon_range,
                             latitude: parseFloat(platform.latitude),
                             longitude: parseFloat(platform.longitude),
-                            toggled: setToggled
+                            toggled: setToggled,
+                            opacity: currentOpacity
                         });
                     }
                 });
@@ -53,7 +55,8 @@ var RangeRingStorage = (function() {
                             range_val: sensorDict[sensorName].sensor_range,
                             latitude: parseFloat(platform.latitude),
                             longitude: parseFloat(platform.longitude),
-                            toggled: setToggled
+                            toggled: setToggled,
+                            opacity: currentOpacity
                         });
                     }
                 });
@@ -82,6 +85,9 @@ var RangeRingStorage = (function() {
 
     function createRangeRing(newRangeRing) {
         if (!getRangeRing(newRangeRing.platform_name, newRangeRing.system_name)) {
+            if (typeof newRangeRing.opacity !== 'number') {
+                newRangeRing.opacity = currentOpacity;
+            }
             rangeRings.push(newRangeRing);
         } else {
             console.warn("Range ring with specified platform and system names already exists.");
@@ -92,12 +98,25 @@ var RangeRingStorage = (function() {
         return JSON.stringify(rangeRings, null, 2);
     }
 
+    function getOpacity() {
+        return currentOpacity;
+    }
+
+    function setOpacity(newOpacity) {
+        currentOpacity = newOpacity;
+        rangeRings.forEach(function(ring) {
+            ring.opacity = currentOpacity;
+        });
+    }
+
     return {
         init: init,
         getAllRangeRings: getAllRangeRings,
         getRangeRing: getRangeRing,
         setRangeRing: setRangeRing,
         createRangeRing: createRangeRing,
-        exportData: exportData
+        exportData: exportData,
+        getOpacity: getOpacity,
+        setOpacity: setOpacity
     };
 })();


### PR DESCRIPTION
## Summary
- add a map tools menu entry for adjusting the opacity applied to range rings
- store and reuse a global range ring opacity value so existing and future rings share the same transparency

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da9291e248832a8fe3ec6afb3062d3