### PR TITLE
Fix weapon deletion for paginated rows

### DIFF
--- a/js/weapons/weapon_config.js
+++ b/js/weapons/weapon_config.js
@@ -103,8 +103,8 @@ var WeaponConfig = (function() {
         
     function bindWeaponActions() {
         // Handle delete weapon
-        $('.delete-weapon').off('click').on('click', function() {
-            var index = $(this).data('index');
+        $('#weaponTable').off('click', '.delete-weapon').on('click', '.delete-weapon', function() {
+            var index = parseInt($(this).data('index'), 10);
             handleWeaponDeletion(index);
         });
 


### PR DESCRIPTION
## Summary
- ensure delete buttons in the weapon configuration dialog use delegated handlers
- allow deletion confirmation dialogs to appear for weapons on paginated DataTables pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dab16e6d20832aa1b30c5c1e4af4ed