### PR TITLE
Add delete-key workflow for removing map platforms

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,6 +148,7 @@
   <script src="js/selection_controller.js"></script>
   <script src="js/table_controller.js"></script>
   <script src="js/platform_copy_controller.js"></script>
+  <script src="js/platform_deletion_controller.js"></script>
 
   <!-- Configuration Menu Scripts -->
   <script src="js/platforms/plat_config.js"></script>

--- a/init.js
+++ b/init.js
@@ -32,5 +32,6 @@ LabelController.init(); // Add labels from LabelStorage to the map
 View.renderPlatforms(); // Add platforms to the map from PlatformModel and add event listeners to each added platform
 SelectionController.init(); // Initialize the selection controller (allows for platforms to be selected and dragged around)
 PlatformCopyController.init(); // Enable copy-paste workflows for selected platforms
+PlatformDeletionController.init(); // Enable deletion of selected platforms via the Delete key
 
 

--- a/js/platform_deletion_controller.js
+++ b/js/platform_deletion_controller.js
@@ -1,0 +1,173 @@
+// platform_deletion_controller.js
+var PlatformDeletionController = (function(
+    View,
+    SelectionController,
+    PlatformModel,
+    RangeRingStorage,
+    RangeRingLogic,
+    DistanceStorage,
+    TableController
+) {
+    var storedToggles = {};
+
+    function init() {
+        document.addEventListener('keydown', handleKeyDown);
+    }
+
+    function handleKeyDown(event) {
+        if (!event || event.key !== 'Delete') {
+            return;
+        }
+
+        if (shouldIgnoreEventTarget()) {
+            return;
+        }
+
+        var selectedMarkers = Array.from(SelectionController.getSelectedMarkers() || []);
+        if (selectedMarkers.length === 0) {
+            return;
+        }
+
+        var platformNames = extractPlatformNames(selectedMarkers);
+        if (platformNames.length === 0) {
+            return;
+        }
+
+        var confirmationMessage = buildConfirmationMessage(platformNames);
+        if (!window.confirm(confirmationMessage)) {
+            return;
+        }
+
+        event.preventDefault();
+        deletePlatforms(platformNames);
+    }
+
+    function shouldIgnoreEventTarget() {
+        var activeElement = document.activeElement;
+        if (!activeElement) {
+            return false;
+        }
+
+        var tagName = activeElement.tagName;
+        if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
+            return true;
+        }
+
+        if (activeElement.isContentEditable) {
+            return true;
+        }
+
+        return false;
+    }
+
+    function extractPlatformNames(markers) {
+        var names = markers
+            .map(function(marker) {
+                if (!marker || !marker._platformName) {
+                    return null;
+                }
+                return marker._platformName;
+            })
+            .filter(Boolean);
+
+        return Array.from(new Set(names));
+    }
+
+    function buildConfirmationMessage(platformNames) {
+        if (platformNames.length === 1) {
+            return 'Delete the selected platform "' + platformNames[0] + '"?\n\nThis action cannot be undone.';
+        }
+
+        var list = platformNames.map(function(name) {
+            return '• ' + name;
+        }).join('\n');
+
+        return 'Delete the ' + platformNames.length + ' selected platforms?\n\n' + list + '\n\nThis action cannot be undone.';
+    }
+
+    function deletePlatforms(platformNames) {
+        if (!Array.isArray(platformNames) || platformNames.length === 0) {
+            return [];
+        }
+
+        var uniqueNames = Array.from(new Set(platformNames.filter(Boolean)));
+        if (uniqueNames.length === 0) {
+            return [];
+        }
+
+        preserveRangeRingToggleState();
+
+        var deletedNames = uniqueNames.filter(function(name) {
+            return PlatformModel.deletePlatform(name);
+        });
+
+        if (deletedNames.length === 0) {
+            storedToggles = {};
+            return [];
+        }
+
+        synchronizeApplicationState();
+
+        return deletedNames;
+    }
+
+    function synchronizeApplicationState() {
+        SelectionController.clearSelectedMarkers();
+
+        RangeRingLogic.clearRangeRings();
+        RangeRingStorage.init();
+        restoreRangeRingToggleState();
+        RangeRingLogic.drawRangeRings();
+
+        DistanceStorage.refreshDistanceData();
+        TableController.redrawTable();
+        View.renderPlatforms();
+        View.updateAll();
+    }
+
+    function preserveRangeRingToggleState() {
+        storedToggles = {};
+        var rings = RangeRingStorage.getAllRangeRings();
+        if (!Array.isArray(rings)) {
+            return;
+        }
+
+        rings.forEach(function(ring) {
+            var key = createRangeRingKey(ring.platform_name, ring.system_name);
+            storedToggles[key] = ring.toggled;
+        });
+    }
+
+    function restoreRangeRingToggleState() {
+        var rings = RangeRingStorage.getAllRangeRings();
+        if (!Array.isArray(rings)) {
+            return;
+        }
+
+        rings.forEach(function(ring) {
+            var key = createRangeRingKey(ring.platform_name, ring.system_name);
+            if (Object.prototype.hasOwnProperty.call(storedToggles, key)) {
+                ring.toggled = storedToggles[key];
+            }
+        });
+
+        storedToggles = {};
+    }
+
+    function createRangeRingKey(platformName, systemName) {
+        return String(platformName) + '|' + String(systemName);
+    }
+
+    return {
+        init: init,
+        deletePlatforms: deletePlatforms
+    };
+})(
+    View,
+    SelectionController,
+    PlatformModel,
+    RangeRingStorage,
+    RangeRingLogic,
+    DistanceStorage,
+    TableController
+);

--- a/js/platforms/plat_config.js
+++ b/js/platforms/plat_config.js
@@ -515,20 +515,12 @@ var PlatformConfig = (function() {
             }
 
             // Proceed with deletion
-            var deletionSuccess = PlatformModel.deletePlatform(platform.platform_name);
+            var deletedNames = PlatformDeletionController.deletePlatforms([platform.platform_name]);
 
             // Close the dialog after deletion
             $('#platformInfoDialog').dialog('close');
 
-            if (deletionSuccess) {
-                // Update platforms in the table view
-                TableController.redrawTable();
-                // Update platforms on the map view
-                View.renderPlatforms();
-                // Update the range rings
-                RangeRingStorage.init();
-
-            } else {
+            if (deletedNames.length === 0) {
                 alert(`Failed to delete platform "${platform.platform_name}". It may not exist.`);
             }
         });


### PR DESCRIPTION
## Summary
- add a PlatformDeletionController that listens for the Delete key, confirms with the user, and synchronizes map, table, range rings, distances, and results after removal
- register the new controller at startup and include its script in the page
- reuse the centralized deletion workflow from the platform configuration dialog

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dbfc489830832a998040d3b51381e0