### PR TITLE
Add platform type management across platform workflows

### DIFF
--- a/input/platform_details.js
+++ b/input/platform_details.js
@@ -34,7 +34,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "BLUE_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "blue_ship_2",
@@ -55,7 +56,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "BLUE_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "blue_ship_3",
@@ -86,7 +88,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "BLUE_SENSOR_1",
       "BLUE_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "blue_ship_4",
@@ -115,7 +118,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "BLUE_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "blue_ship_5",
@@ -137,7 +141,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "BLUE_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "blue_ship_6",
@@ -171,7 +176,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "BLUE_SENSOR_2",
       "BLUE_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "blue_ship_7",
@@ -194,7 +200,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "BLUE_SENSOR_2",
       "BLUE_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "blue_ship_8",
@@ -232,7 +239,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "BLUE_SENSOR_2",
       "BLUE_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "blue_ship_9",
@@ -254,7 +262,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "BLUE_SENSOR_1",
       "BLUE_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "blue_ship_10",
@@ -288,7 +297,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "BLUE_SENSOR_2",
       "BLUE_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_1",
@@ -315,7 +325,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_2",
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_2",
@@ -357,7 +368,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_3",
@@ -407,7 +419,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_2",
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_4",
@@ -429,7 +442,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_5",
@@ -480,7 +494,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_6",
@@ -530,7 +545,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_7",
@@ -559,7 +575,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_8",
@@ -597,7 +614,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_9",
@@ -643,7 +661,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_10",
@@ -669,7 +688,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_11",
@@ -692,7 +712,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_12",
@@ -739,7 +760,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_13",
@@ -768,7 +790,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_14",
@@ -802,7 +825,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_15",
@@ -829,7 +853,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_16",
@@ -866,7 +891,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_17",
@@ -897,7 +923,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_18",
@@ -924,7 +951,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_19",
@@ -974,7 +1002,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_20",
@@ -1020,7 +1049,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_21",
@@ -1061,7 +1091,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_22",
@@ -1088,7 +1119,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_23",
@@ -1134,7 +1166,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_24",
@@ -1164,7 +1197,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_25",
@@ -1198,7 +1232,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_26",
@@ -1219,7 +1254,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_27",
@@ -1246,7 +1282,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_28",
@@ -1269,7 +1306,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_2",
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_29",
@@ -1303,7 +1341,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_2",
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_30",
@@ -1345,7 +1384,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_31",
@@ -1366,7 +1406,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_32",
@@ -1404,7 +1445,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_33",
@@ -1439,7 +1481,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_2",
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_34",
@@ -1478,7 +1521,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_35",
@@ -1507,7 +1551,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_36",
@@ -1532,7 +1577,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_37",
@@ -1558,7 +1604,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_38",
@@ -1581,7 +1628,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_39",
@@ -1631,7 +1679,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_40",
@@ -1664,7 +1713,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_41",
@@ -1697,7 +1747,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_42",
@@ -1743,7 +1794,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_2",
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_43",
@@ -1773,7 +1825,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_44",
@@ -1814,7 +1867,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_45",
@@ -1845,7 +1899,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_46",
@@ -1879,7 +1934,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_47",
@@ -1930,7 +1986,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_48",
@@ -1959,7 +2016,8 @@ var PLATFORM_DATA = [
     ],
     "sensors": [
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_49",
@@ -2002,7 +2060,8 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_1",
       "RED_SENSOR_2"
-    ]
+    ],
+    "type": "Unspecified"
   },
   {
     "platform_name": "red_ship_50",
@@ -2040,6 +2099,7 @@ var PLATFORM_DATA = [
     "sensors": [
       "RED_SENSOR_2",
       "RED_SENSOR_1"
-    ]
+    ],
+    "type": "Unspecified"
   }
 ];

--- a/js/platforms/create_plat_config.js
+++ b/js/platforms/create_plat_config.js
@@ -29,6 +29,10 @@ var CreatePlatConfig = (function () {
                         <td><input type="text" id="category" required></td>
                     </tr>
                     <tr>
+                        <td><label for="type">Type:</label></td>
+                        <td><input type="text" id="type" required></td>
+                    </tr>
+                    <tr>
                         <td><label for="latitude">Latitude:</label></td>
                         <td><input type="number" id="latitude" step="0.00001" value="0"></td>
                     </tr>
@@ -67,16 +71,17 @@ var CreatePlatConfig = (function () {
         // Handle create platform button click using event delegation
         $('#createPlatformContent').off('click', '#createPlatformButton').on('click', '#createPlatformButton', function() {
             console.log('Create Platform button clicked');
-            var platformName = $('#platformName').val();
+            var platformName = ($('#platformName').val() || '').trim();
             var side = $('#side').val();
-            var group = $('#group').val();
-            var category = $('#category').val();
+            var group = ($('#group').val() || '').trim();
+            var category = ($('#category').val() || '').trim();
+            var type = ($('#type').val() || '').trim();
             var latitude = $('#latitude').val() || "0";
             var longitude = $('#longitude').val() || "0";
             var altitude = $('#altitude').val() || "0";
 
             // Validate required fields
-            if (!platformName || !side || !group || !category) {
+            if (!platformName || !side || !group || !category || !type) {
                 console.warn('Validation failed: Missing required fields');
                 alert('Please fill in all required fields.');
                 return;
@@ -107,6 +112,7 @@ var CreatePlatConfig = (function () {
                 longitude: longitude,
                 altitude: altitude,
                 category: category,
+                type: type,
                 weapons: [],
                 sensors: []
             };

--- a/js/platforms/plat_config.js
+++ b/js/platforms/plat_config.js
@@ -82,8 +82,20 @@ var PlatformConfig = (function() {
                             <td><label for="platformGroupInput"><strong>Group:</strong></label></td>
                             <td><input type="text" id="platformGroupInput" value="${platform.group}" class="full-width"></td>
                         </tr>
-                        
-                        <!-- Row 3: Side -->
+
+                        <!-- Row 3: Category -->
+                        <tr>
+                            <td><label for="platformCategoryInput"><strong>Category:</strong></label></td>
+                            <td><input type="text" id="platformCategoryInput" value="${platform.category || ''}" class="full-width"></td>
+                        </tr>
+
+                        <!-- Row 4: Type -->
+                        <tr>
+                            <td><label for="platformTypeInput"><strong>Type:</strong></label></td>
+                            <td><input type="text" id="platformTypeInput" value="${platform.type && platform.type !== 'Unspecified' ? platform.type : ''}" class="full-width"></td>
+                        </tr>
+
+                        <!-- Row 5: Side -->
                         <tr>
                             <td><label for="platformSideInput"><strong>Side:</strong></label></td>
                             <td>
@@ -94,19 +106,19 @@ var PlatformConfig = (function() {
                             </td>
                         </tr>
                         
-                        <!-- Row 4: Latitude -->
+                        <!-- Row 6: Latitude -->
                         <tr>
                             <td><label for="platformLatitudeInput"><strong>Latitude:</strong></label></td>
                             <td><input type="text" id="platformLatitudeInput" value="${platform.latitude}" class="full-width"></td>
                         </tr>
-                        
-                        <!-- Row 5: Longitude -->
+
+                        <!-- Row 7: Longitude -->
                         <tr>
                             <td><label for="platformLongitudeInput"><strong>Longitude:</strong></label></td>
                             <td><input type="text" id="platformLongitudeInput" value="${platform.longitude}" class="full-width"></td>
                         </tr>
-                        
-                        <!-- Row 6: Altitude -->
+
+                        <!-- Row 8: Altitude -->
                         <tr>
                             <td><label for="platformAltitudeInput"><strong>Altitude:</strong></label></td>
                             <td><input type="text" id="platformAltitudeInput" value="${platform.altitude}" class="full-width"></td>
@@ -533,6 +545,8 @@ var PlatformConfig = (function() {
         var newName = $('#platformNameInput').val();
         var newSide = $('#platformSideInput').val();
         var newGroup = $('#platformGroupInput').val();
+        var newCategory = ($('#platformCategoryInput').val() || '').trim();
+        var newType = ($('#platformTypeInput').val() || '').trim();
         var newLat = $('#platformLatitudeInput').val();
         var newLon = $('#platformLongitudeInput').val();
         var newAlt = $('#platformAltitudeInput').val();
@@ -565,6 +579,8 @@ var PlatformConfig = (function() {
             platformToUpdate.platform_name = newName;
             platformToUpdate.side = newSide;
             platformToUpdate.group = newGroup;
+            platformToUpdate.category = newCategory || 'Unspecified';
+            platformToUpdate.type = newType || 'Unspecified';
             platformToUpdate.latitude = newLat;
             platformToUpdate.longitude = newLon;
             platformToUpdate.altitude = newAlt;

--- a/js/platforms/platform_model.js
+++ b/js/platforms/platform_model.js
@@ -7,7 +7,13 @@ var PlatformModel = (function() {
     // platformData
     function loadInitialData(PLATFORM_DATA) {
         platformData = PLATFORM_DATA.map(function(item) {
-            return Object.assign({}, item);
+            var copy = Object.assign({}, item);
+            if (!copy.type || (typeof copy.type === 'string' && copy.type.trim() === '')) {
+                copy.type = 'Unspecified';
+            } else if (typeof copy.type === 'string') {
+                copy.type = copy.type.trim();
+            }
+            return copy;
         });
     }
 
@@ -42,7 +48,7 @@ var PlatformModel = (function() {
     }
 
     // Function to create and add a platform to platformData
-    function createPlatform(platformName, side, group, subgroups, latitude, longitude, altitude, category, weapons, sensors) {
+    function createPlatform(platformName, side, group, subgroups, latitude, longitude, altitude, category, type, weapons, sensors) {
         var newPlatform = {
             platform_name: platformName,
             side: side,
@@ -52,6 +58,7 @@ var PlatformModel = (function() {
             longitude: longitude,
             altitude: altitude,
             category: category,
+            type: (typeof type === 'string' && type.trim() !== '') ? type.trim() : 'Unspecified',
             weapons: weapons,
             sensors: sensors
         };
@@ -60,6 +67,11 @@ var PlatformModel = (function() {
 
     // Function to add an already defined platform object to platformData
     function pushPlatform(newPlatform) {
+        if (!newPlatform.type || (typeof newPlatform.type === 'string' && newPlatform.type.trim() === '')) {
+            newPlatform.type = 'Unspecified';
+        } else if (typeof newPlatform.type === 'string') {
+            newPlatform.type = newPlatform.type.trim();
+        }
         platformData.push(newPlatform);
     }
 

--- a/js/table_controller.js
+++ b/js/table_controller.js
@@ -29,7 +29,9 @@ var TableController = (function() {
                 { title: "Name", data: "platform_name" },
                 { title: "Side", data: "side" },
                 { title: "Group", data: "group" },
-                { title: "Subgroup", data: function(row) { 
+                { title: "Category", data: "category" },
+                { title: "Type", data: "type" },
+                { title: "Subgroup", data: function(row) {
                     return row.subgroups && row.subgroups.length > 0 ? row.subgroups[0] : "";
                 }},
                 { 

--- a/js/view.js
+++ b/js/view.js
@@ -153,11 +153,15 @@ var View = (function() {
             // Store the platform name on the marker for external reference (e.g., copy/paste)
             marker._platformName = platform.platform_name;
 
-            // Add tooltip to display the platform name on hover
-            marker.bindTooltip(platform.platform_name, 
-                { 
-                    permanent: false, 
-                    direction: "top" 
+            // Add tooltip to display the platform name (and type when available) on hover
+            var tooltipText = platform.platform_name;
+            if (platform.type && platform.type !== 'Unspecified') {
+                tooltipText += ' (' + platform.type + ')';
+            }
+            marker.bindTooltip(tooltipText,
+                {
+                    permanent: false,
+                    direction: "top"
                 });
             platformMarkers[platform.platform_name] = marker;
 


### PR DESCRIPTION
## Summary
- add a defaulted `type` property to the platform dataset and model helpers to keep missing values consistent
- enable entering and editing platform type details through the creation and configuration dialogs and refresh dependent views
- extend the main platform table and map tooltips to display the new type information for each platform

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68dd1df9d764832a9dea99a5faa0d8cc