### PR TITLE
Fix Clear Range Rings button to reset toggles

### DIFF
--- a/js/range_rings/range_ring_logic.js
+++ b/js/range_rings/range_ring_logic.js
@@ -142,6 +142,23 @@ var RangeRingLogic = (function() {
     rangeRingLayers = [];
   }
 
+  function clearAllRangeRings() {
+    RangeRingStorage.setAllRangeRingToggleStates(0);
+    clearRangeRings();
+    updateRangeRingConfigCheckboxes();
+  }
+
+  function updateRangeRingConfigCheckboxes() {
+    var checkboxes = document.querySelectorAll('#rangeRingTable .range-toggle');
+    if (!checkboxes || !checkboxes.length) {
+      return;
+    }
+
+    checkboxes.forEach(function(checkbox) {
+      checkbox.checked = false;
+    });
+  }
+
   function setRangeRingOpacity(opacity) {
     var parsed = parseFloat(opacity);
     if (!isFinite(parsed)) {
@@ -166,6 +183,7 @@ var RangeRingLogic = (function() {
     drawRangeRings: drawRangeRings,
     drawRangeRingForPlatform: drawRangeRingForPlatform,
     clearRangeRings: clearRangeRings,
+    clearAllRangeRings: clearAllRangeRings,
     setRangeRingOpacity: setRangeRingOpacity,
     getRangeRingOpacity: getRangeRingOpacity
   };

--- a/js/range_rings/range_ring_storage.js
+++ b/js/range_rings/range_ring_storage.js
@@ -88,6 +88,14 @@ var RangeRingStorage = (function() {
         }
     }
 
+    function setAllRangeRingToggleStates(toggled) {
+        var normalized = toggled ? 1 : 0;
+
+        rangeRings.forEach(function(ring) {
+            ring.toggled = normalized;
+        });
+    }
+
     function exportData() {
         return JSON.stringify(rangeRings, null, 2);
     }
@@ -98,6 +106,7 @@ var RangeRingStorage = (function() {
         getRangeRing: getRangeRing,
         setRangeRing: setRangeRing,
         createRangeRing: createRangeRing,
+        setAllRangeRingToggleStates: setAllRangeRingToggleStates,
         exportData: exportData
     };
 })();

--- a/js/view.js
+++ b/js/view.js
@@ -88,7 +88,7 @@ var View = (function() {
 
         // Add Clear Range Rings button functionality
         document.getElementById('clearRangeRingsButton').addEventListener('click', function() {
-            RangeRingLogic.clearRangeRings();
+            RangeRingLogic.clearAllRangeRings();
         });
 
         // Add Export Laydown button functionality


### PR DESCRIPTION
## Summary
- add storage helper to update all range ring toggle states at once
- ensure the Clear Range Rings button resets toggles and checkbox UI while clearing the map layers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de72c9fb04832aa829bc401a787064