### PR TITLE
Enable measurement interactions on platform markers

### DIFF
--- a/js/view.js
+++ b/js/view.js
@@ -147,7 +147,8 @@ var View = (function() {
             // Create the marker with the custom icon and dragging disabled initially
             var marker = L.marker([platform.latitude, platform.longitude], {
                 icon: icon,
-                draggable: false
+                draggable: false,
+                bubblingMouseEvents: true
             }).addTo(map);
 
             // Store the platform name on the marker for external reference (e.g., copy/paste)


### PR DESCRIPTION
## Summary
- allow platform markers to bubble mouse events so the map ruler can start measurements on them

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de82320d4c832ab49f6e1e586d845d