### PR TITLE
Create dynamic main menu button layout

### DIFF
--- a/css/walt-menu-styles.css
+++ b/css/walt-menu-styles.css
@@ -113,48 +113,55 @@
   /* Button Container & Custom Buttons             */
   /* ============================================= */
   .button-container {
+    --button-gap: 12px;
+    --button-row-gap: 16px;
+    --button-min-width: clamp(140px, 28%, 260px);
+    --button-min-height: clamp(44px, 4vw, 70px);
+    --button-font-size: clamp(0.9rem, 0.8vw + 0.7rem, 1.3rem);
     display: flex;
     flex-direction: column;
-    gap: 15px; 
+    align-items: stretch;
+    gap: var(--button-row-gap);
     padding: 10px;
   }
-  
-  .side-by-side {
+
+  .button-container .button-row {
     display: flex;
-    gap: 10px; /* Space between individual buttons */
+    flex-wrap: wrap;
+    gap: var(--button-gap);
   }
-  
+
   .custom-button {
     background-color: #1b1d1b86;
     color: white;
-    padding: 10px 20px;
     border: none;
-    border-radius: 5px; 
+    border-radius: 5px;
     cursor: pointer;
-    font-size: 16px;
-    transition: background-color 0.3s ease, transform 0.2s ease; 
-    flex: 1; /* Make buttons take equal space within side-by-side */
+    font-size: var(--button-font-size);
+    line-height: 1.2;
+    padding: clamp(0.6rem, 0.4vw + 0.5rem, 0.85rem) clamp(1rem, 0.9vw + 0.75rem, 1.6rem);
+    transition: background-color 0.3s ease, transform 0.2s ease;
+    flex: var(--button-col-span, 1) 1 var(--button-min-width);
+    min-height: var(--button-min-height);
     text-align: center;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); 
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    white-space: normal;
   }
-  
+
   .custom-button:hover {
     background-color: #bcc0bccb;
     transform: translateY(-2px); /* Slight lift on hover */
   }
-  
+
   .custom-button:active {
     background-color: #3e8e41;
-    transform: translateY(0); 
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2); 
+    transform: translateY(0);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   }
-  
+
   @media (max-width: 600px) {
-    .side-by-side {
-      flex-direction: column;
-    }
-    .custom-button {
-      width: 100%;
+    .button-container {
+      --button-min-width: min(100%, 220px);
     }
   }
   

--- a/css/walt-menu-styles.css
+++ b/css/walt-menu-styles.css
@@ -115,9 +115,9 @@
   .button-container {
     --button-gap: 12px;
     --button-row-gap: 16px;
-    --button-min-width: clamp(140px, 28%, 260px);
-    --button-min-height: clamp(44px, 4vw, 70px);
-    --button-font-size: clamp(0.9rem, 0.8vw + 0.7rem, 1.3rem);
+    --button-min-width: clamp(110px, 24%, 260px);
+    --button-min-height: clamp(38px, 3.6vw, 70px);
+    --button-font-size: clamp(0.8rem, 0.75vw + 0.6rem, 1.25rem);
     display: flex;
     flex-direction: column;
     align-items: stretch;
@@ -139,7 +139,7 @@
     cursor: pointer;
     font-size: var(--button-font-size);
     line-height: 1.2;
-    padding: clamp(0.6rem, 0.4vw + 0.5rem, 0.85rem) clamp(1rem, 0.9vw + 0.75rem, 1.6rem);
+    padding: clamp(0.5rem, 0.35vw + 0.45rem, 0.8rem) clamp(0.85rem, 0.8vw + 0.65rem, 1.6rem);
     transition: background-color 0.3s ease, transform 0.2s ease;
     flex: var(--button-col-span, 1) 1 var(--button-min-width);
     min-height: var(--button-min-height);
@@ -159,9 +159,22 @@
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   }
 
-  @media (max-width: 600px) {
+  @media (max-width: 750px) {
     .button-container {
-      --button-min-width: min(100%, 220px);
+      --button-gap: 10px;
+      --button-row-gap: 14px;
+      --button-min-width: clamp(100px, 32vw, 220px);
+      --button-font-size: clamp(0.78rem, 1vw + 0.52rem, 1.15rem);
+    }
+  }
+
+  @media (max-width: 520px) {
+    .button-container {
+      --button-gap: 8px;
+      --button-row-gap: 12px;
+      --button-min-width: clamp(92px, 44vw, 200px);
+      --button-min-height: clamp(34px, 5.5vw, 60px);
+      --button-font-size: clamp(0.72rem, 1.1vw + 0.45rem, 1.05rem);
     }
   }
   

--- a/index.html
+++ b/index.html
@@ -66,23 +66,7 @@
     <!-- Data Table -->
     <table id="platformTable" class="display"></table>
     <!-- Button Controls -->
-    <div class="button-container">
-      <!-- Add New Platform Button -->
-      <div class="custom-button" id="createPlatformButton">Add New Platform</div>
-      <!-- Configuration Buttons Group -->
-      <div class="side-by-side">
-        <div class="custom-button" id="rangeRingsButton">Range Rings</div>
-        <div class="custom-button" id="weaponsButton">Weapons</div>
-        <div class="custom-button" id="sensorsButton">Sensors</div>
-      </div>
-      <!-- Display results and send updated data to results page -->
-      <div class="side-by-side">
-        <div class="custom-button" id="openChartsButton">Display Results</div>
-        <div class="custom-button" id="refreshDataButton">Refresh Data</div>
-      </div>
-      <!-- Export Functionality -->
-      <div class="custom-button" id="exportLaydownButton">Export Laydown</div>
-    </div>
+    <div class="button-container" id="mainMenuButtonContainer"></div>
   </div>
 
   <!-------------------------------------------------------->
@@ -132,6 +116,7 @@
   <script src="js/labels/label_storage.js"></script>
   <script src="js/export_laydown.js"></script>
   <script src="js/map_tools/map_tools_menu.js"></script>
+  <script src="js/menu/main_menu_button_layout.js"></script>
   <script src="js/view.js"></script>
 
 

--- a/js/menu/main_menu_button_layout.js
+++ b/js/menu/main_menu_button_layout.js
@@ -1,0 +1,96 @@
+// js/menu/main_menu_button_layout.js
+// Creates the dynamic main menu button container based on a configurable layout
+
+var MainMenuButtons = (function() {
+  /**
+   * Default layout for the main menu buttons. Each array entry represents a row,
+   * and every object inside the row describes an individual button. To change
+   * which buttons appear next to one another, simply edit the rows below or
+   * provide a new layout to `MainMenuButtons.applyLayout`.
+   */
+  const defaultLayout = [
+    [
+      { id: 'createPlatformButton', label: 'Add New Platform' }
+    ],
+    [
+      { id: 'rangeRingsButton', label: 'Range Rings' },
+      { id: 'weaponsButton', label: 'Weapons' },
+      { id: 'sensorsButton', label: 'Sensors' }
+    ],
+    [
+      { id: 'openChartsButton', label: 'Display Results' },
+      { id: 'refreshDataButton', label: 'Refresh Data' }
+    ],
+    [
+      { id: 'exportLaydownButton', label: 'Export Laydown' }
+    ]
+  ];
+
+  const CONTAINER_ID = 'mainMenuButtonContainer';
+
+  /**
+   * Builds a single button element based on the provided configuration.
+   * @param {Object} config
+   * @returns {HTMLButtonElement}
+   */
+  function createButton(config) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.id = config.id;
+    button.classList.add('custom-button');
+    button.textContent = config.label;
+
+    if (Array.isArray(config.classes)) {
+      config.classes.forEach(function(className) {
+        button.classList.add(className);
+      });
+    }
+
+    if (config.title) {
+      button.title = config.title;
+    }
+
+    if (config.colSpan) {
+      button.style.setProperty('--button-col-span', config.colSpan);
+    }
+
+    return button;
+  }
+
+  /**
+   * Clears the existing container and renders the new layout.
+   * @param {Array<Array<Object>>} layout
+   */
+  function render(layout) {
+    const container = document.getElementById(CONTAINER_ID);
+    if (!container) {
+      return;
+    }
+
+    container.innerHTML = '';
+
+    layout.forEach(function(rowConfig) {
+      const row = document.createElement('div');
+      row.classList.add('button-row');
+
+      rowConfig.forEach(function(buttonConfig) {
+        row.appendChild(createButton(buttonConfig));
+      });
+
+      container.appendChild(row);
+    });
+  }
+
+  return {
+    applyLayout: function(layout) {
+      render(Array.isArray(layout) ? layout : defaultLayout);
+    },
+    getDefaultLayout: function() {
+      return JSON.parse(JSON.stringify(defaultLayout));
+    }
+  };
+})();
+
+// Render the default layout immediately so that other scripts can attach
+// event listeners to the generated buttons.
+MainMenuButtons.applyLayout();


### PR DESCRIPTION
## Summary
- replace the static main menu button markup with a generated container and include the new layout script
- add a configurable layout builder so main menu buttons can be reorganized by editing a single array
- refresh the button styling to scale fonts and spacing responsively as the viewport changes

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de87403f80832a9ad1aa0ec7c07474