### PR TITLE
Make platform table height and typography responsive

### DIFF
--- a/css/walt-menu-styles.css
+++ b/css/walt-menu-styles.css
@@ -109,6 +109,7 @@
     padding: var(--table-cell-padding);
     text-align: left;
     line-height: var(--table-line-height);
+    white-space: nowrap;
   }
 
   #platformTable thead th {
@@ -125,6 +126,7 @@
     font-size: var(--table-header-font-size);
     padding: var(--table-cell-padding);
     line-height: var(--table-line-height);
+    white-space: nowrap;
   }
 
   #platformTableContainer .dataTables_scrollBody table tbody td,
@@ -132,7 +134,7 @@
     font-size: var(--table-font-size);
     padding: var(--table-cell-padding);
     line-height: var(--table-line-height);
-    word-break: break-word;
+    white-space: nowrap;
   }
 
   #platformTableContainer .dataTables_scrollHead table,

--- a/css/walt-menu-styles.css
+++ b/css/walt-menu-styles.css
@@ -13,7 +13,11 @@
 /* Platform Table Container                      */
 /* ============================================= */
 #platformTableContainer {
-    overflow-y: auto;
+    --table-font-size: 14px;
+    --table-header-font-size: 15px;
+    --table-cell-padding: 10px;
+    --table-line-height: 1.4;
+    overflow: hidden;
     width: 35%;
     height: 100vh;
     float: right;
@@ -21,10 +25,46 @@
     flex-direction: column;
     padding: 20px;
     box-sizing: border-box;
-    border: 2px solid #ddd; 
+    border: 2px solid #ddd;
     background-color: #f9f9f9;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); 
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    gap: 16px;
   }
+
+#platformTableContainer .platform-table-header {
+    flex: 0 0 auto;
+}
+
+#platformTableContainer .dataTables_wrapper {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+#platformTableContainer .dataTables_filter,
+#platformTableContainer .dataTables_length {
+    flex: 0 0 auto;
+    margin-bottom: 8px;
+}
+
+#platformTableContainer .dataTables_scroll {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+#platformTableContainer .dataTables_scrollBody {
+    flex: 1 1 auto !important;
+    min-height: 0;
+}
+
+#platformTableContainer .dataTables_info,
+#platformTableContainer .dataTables_paginate {
+    flex: 0 0 auto;
+    margin-top: 8px;
+}
   
   /* ============================================= */
   /* Platform Table Header                         */
@@ -66,8 +106,40 @@
   
   #platformTable th,
   #platformTable td {
-    padding: 10px;
+    padding: var(--table-cell-padding);
     text-align: left;
+    line-height: var(--table-line-height);
+  }
+
+  #platformTable thead th {
+    font-size: var(--table-header-font-size);
+  }
+
+  #platformTable tbody td,
+  #platformTable tbody th {
+    font-size: var(--table-font-size);
+  }
+
+  #platformTableContainer .dataTables_scrollHead table thead th,
+  #platformTableContainer .dataTables_scrollBody table thead th {
+    font-size: var(--table-header-font-size);
+    padding: var(--table-cell-padding);
+    line-height: var(--table-line-height);
+  }
+
+  #platformTableContainer .dataTables_scrollBody table tbody td,
+  #platformTableContainer .dataTables_scrollBody table tbody th {
+    font-size: var(--table-font-size);
+    padding: var(--table-cell-padding);
+    line-height: var(--table-line-height);
+    word-break: break-word;
+  }
+
+  #platformTableContainer .dataTables_scrollHead table,
+  #platformTableContainer .dataTables_scrollBody table {
+    width: auto !important;
+    min-width: 100%;
+    table-layout: auto;
   }
   
   /* ============================================= */

--- a/css/walt-menu-styles.css
+++ b/css/walt-menu-styles.css
@@ -13,8 +13,8 @@
 /* Platform Table Container                      */
 /* ============================================= */
 #platformTableContainer {
-    --table-font-size: 14px;
-    --table-header-font-size: 15px;
+    --table-font-size: 13px;
+    --table-header-font-size: 14px;
     --table-cell-padding: 10px;
     --table-line-height: 1.4;
     overflow: hidden;

--- a/js/table_controller.js
+++ b/js/table_controller.js
@@ -24,7 +24,9 @@ var TableController = (function() {
     var BASE_FONT_SIZE = 13;
     var BASE_HEADER_FONT_SIZE = 14;
     var BASE_PADDING = 10;
-    var MIN_SCALE = 0.5;
+    var MIN_SCALE = 0.3;
+    var SCALE_EPSILON = 0.005;
+    var SCALE_ITERATIONS = 14;
 
     function calculateTableHeight() {
         var $container = $('#platformTableContainer');
@@ -54,7 +56,7 @@ var TableController = (function() {
             return;
         }
 
-        var fontSize = Math.max(10, Math.round(BASE_FONT_SIZE * scale * 10) / 10);
+        var fontSize = Math.max(8, Math.round(BASE_FONT_SIZE * scale * 10) / 10);
         var headerFontSize = Math.max(fontSize + 1, Math.round(BASE_HEADER_FONT_SIZE * scale * 10) / 10);
         var padding = Math.max(4, Math.round(BASE_PADDING * scale));
         var lineHeight = Math.max(1.1, (1.2 + (scale * 0.4)).toFixed(2));
@@ -67,9 +69,59 @@ var TableController = (function() {
         });
     }
 
+    function detectWrapping($tables) {
+        if (typeof window === 'undefined') {
+            return false;
+        }
+
+        var hasWrapping = false;
+
+        $tables.each(function() {
+            if (hasWrapping) {
+                return false;
+            }
+
+            var cells = this.querySelectorAll('thead th, tbody td, tbody th');
+            for (var i = 0; i < cells.length; i++) {
+                var cell = cells[i];
+                if (!cell) {
+                    continue;
+                }
+
+                var scrollWidth = cell.scrollWidth;
+                var clientWidth = cell.clientWidth;
+                if (scrollWidth - clientWidth > 1) {
+                    hasWrapping = true;
+                    break;
+                }
+
+                var computed = window.getComputedStyle(cell);
+                if (!computed) {
+                    continue;
+                }
+
+                var lineHeight = parseFloat(computed.lineHeight);
+                if (isNaN(lineHeight)) {
+                    lineHeight = parseFloat(computed.fontSize) * 1.2;
+                }
+
+                var paddingTop = parseFloat(computed.paddingTop) || 0;
+                var paddingBottom = parseFloat(computed.paddingBottom) || 0;
+                var expectedHeight = lineHeight + paddingTop + paddingBottom;
+                if (cell.scrollHeight - expectedHeight > 1.5) {
+                    hasWrapping = true;
+                    break;
+                }
+            }
+        });
+
+        return hasWrapping;
+    }
+
     function measureTableWidths() {
         var $container = $('#platformTableContainer');
         var $scrollBody = $container.find('.dataTables_scrollBody');
+        var $tables = $container.find('.dataTables_scrollBody table.dataTable, .dataTables_scrollHead table.dataTable');
         var $table = $scrollBody.find('table.dataTable').first();
 
         if (!$scrollBody.length || !$table.length) {
@@ -84,7 +136,8 @@ var TableController = (function() {
 
         return {
             containerWidth: containerWidth,
-            tableWidth: tableWidth
+            tableWidth: tableWidth,
+            hasWrapping: detectWrapping($tables)
         };
     }
 
@@ -94,32 +147,34 @@ var TableController = (function() {
         }
 
         setTableScale(1);
+        dataTableInstance.columns.adjust();
 
         var measurements = measureTableWidths();
         if (!measurements || !measurements.containerWidth) {
             return;
         }
 
-        if (measurements.tableWidth <= measurements.containerWidth) {
+        if (measurements.tableWidth <= measurements.containerWidth && !measurements.hasWrapping) {
             dataTableInstance.columns.adjust();
             return;
         }
 
         var lower = MIN_SCALE;
         var upper = 1;
-        var bestScale = lower;
+        var bestScale = null;
         var iterations = 0;
 
-        while (upper - lower > 0.01 && iterations < 10) {
+        while (upper - lower > SCALE_EPSILON && iterations < SCALE_ITERATIONS) {
             var mid = (lower + upper) / 2;
             setTableScale(mid);
+            dataTableInstance.columns.adjust();
             measurements = measureTableWidths();
 
             if (!measurements) {
                 break;
             }
 
-            if (measurements.tableWidth > measurements.containerWidth && mid > MIN_SCALE) {
+            if ((measurements.tableWidth > measurements.containerWidth || measurements.hasWrapping) && mid > MIN_SCALE) {
                 upper = mid;
             } else {
                 bestScale = mid;
@@ -129,8 +184,18 @@ var TableController = (function() {
             iterations++;
         }
 
+        if (bestScale === null) {
+            bestScale = MIN_SCALE;
+        }
+
         setTableScale(Math.max(MIN_SCALE, Math.min(1, bestScale)));
         dataTableInstance.columns.adjust();
+
+        measurements = measureTableWidths();
+        if (measurements && (measurements.tableWidth > measurements.containerWidth || measurements.hasWrapping)) {
+            setTableScale(MIN_SCALE);
+            dataTableInstance.columns.adjust();
+        }
     }
 
     function applyTableSizing() {

--- a/js/table_controller.js
+++ b/js/table_controller.js
@@ -21,8 +21,8 @@
 var TableController = (function() {
     var dataTableInstance = null;
     var resizeTimer = null;
-    var BASE_FONT_SIZE = 14;
-    var BASE_HEADER_FONT_SIZE = 15;
+    var BASE_FONT_SIZE = 13;
+    var BASE_HEADER_FONT_SIZE = 14;
     var BASE_PADDING = 10;
     var MIN_SCALE = 0.5;
 

--- a/js/table_controller.js
+++ b/js/table_controller.js
@@ -1,29 +1,188 @@
 /* table_controller.js */
 
 /* This file contains the TableController module, which controls
-   the initialization and management the platform table 
-   on the main WALT page. 
+   the initialization and management the platform table
+   on the main WALT page.
 
    The module contains two funcitons:
    init():
       > Creates the platform table using the JQuery DataTables
       library
-      > Sets the column headers and fills the cells with 
+      > Sets the column headers and fills the cells with
       platform data from the PlatformModel module
       > Sets up event handlers for click-actions for rows
         (e.g. shift-click to select platforms from the table)
 
    redrawTable():
       > Updates the platform table with platform data from
-      the PlatformModel module 
+      the PlatformModel module
 
 */
 var TableController = (function() {
+    var dataTableInstance = null;
+    var resizeTimer = null;
+    var BASE_FONT_SIZE = 14;
+    var BASE_HEADER_FONT_SIZE = 15;
+    var BASE_PADDING = 10;
+    var MIN_SCALE = 0.5;
+
+    function calculateTableHeight() {
+        var $container = $('#platformTableContainer');
+        if ($container.length === 0) {
+            return 300;
+        }
+
+        var containerHeight = $container.height();
+        var headerHeight = $container.find('.platform-table-header').outerHeight(true) || 0;
+        var buttonHeight = $('#mainMenuButtonContainer').outerHeight(true) || 0;
+        var controlsHeight = 0;
+
+        var $wrapper = $container.find('.dataTables_wrapper');
+        if ($wrapper.length) {
+            $wrapper.children('.dataTables_filter, .dataTables_length, .dataTables_info, .dataTables_paginate').each(function() {
+                controlsHeight += $(this).outerHeight(true) || 0;
+            });
+        }
+
+        var availableHeight = containerHeight - headerHeight - buttonHeight - controlsHeight - 16;
+        return Math.max(availableHeight, 200);
+    }
+
+    function setTableScale(scale) {
+        var $container = $('#platformTableContainer');
+        if (!$container.length) {
+            return;
+        }
+
+        var fontSize = Math.max(10, Math.round(BASE_FONT_SIZE * scale * 10) / 10);
+        var headerFontSize = Math.max(fontSize + 1, Math.round(BASE_HEADER_FONT_SIZE * scale * 10) / 10);
+        var padding = Math.max(4, Math.round(BASE_PADDING * scale));
+        var lineHeight = Math.max(1.1, (1.2 + (scale * 0.4)).toFixed(2));
+
+        $container.css({
+            '--table-font-size': fontSize + 'px',
+            '--table-header-font-size': headerFontSize + 'px',
+            '--table-cell-padding': padding + 'px',
+            '--table-line-height': lineHeight
+        });
+    }
+
+    function measureTableWidths() {
+        var $container = $('#platformTableContainer');
+        var $scrollBody = $container.find('.dataTables_scrollBody');
+        var $table = $scrollBody.find('table.dataTable').first();
+
+        if (!$scrollBody.length || !$table.length) {
+            return null;
+        }
+
+        var containerWidth = $scrollBody.innerWidth();
+        var tableWidth = Math.max(
+            $table[0].scrollWidth,
+            $scrollBody.length ? $scrollBody[0].scrollWidth : 0
+        );
+
+        return {
+            containerWidth: containerWidth,
+            tableWidth: tableWidth
+        };
+    }
+
+    function applyTableScale() {
+        if (!dataTableInstance) {
+            return;
+        }
+
+        setTableScale(1);
+
+        var measurements = measureTableWidths();
+        if (!measurements || !measurements.containerWidth) {
+            return;
+        }
+
+        if (measurements.tableWidth <= measurements.containerWidth) {
+            dataTableInstance.columns.adjust();
+            return;
+        }
+
+        var lower = MIN_SCALE;
+        var upper = 1;
+        var bestScale = lower;
+        var iterations = 0;
+
+        while (upper - lower > 0.01 && iterations < 10) {
+            var mid = (lower + upper) / 2;
+            setTableScale(mid);
+            measurements = measureTableWidths();
+
+            if (!measurements) {
+                break;
+            }
+
+            if (measurements.tableWidth > measurements.containerWidth && mid > MIN_SCALE) {
+                upper = mid;
+            } else {
+                bestScale = mid;
+                lower = mid;
+            }
+
+            iterations++;
+        }
+
+        setTableScale(Math.max(MIN_SCALE, Math.min(1, bestScale)));
+        dataTableInstance.columns.adjust();
+    }
+
+    function applyTableSizing() {
+        if (!dataTableInstance) {
+            return;
+        }
+
+        var newHeight = calculateTableHeight();
+        var heightValue = newHeight + 'px';
+        var settings = dataTableInstance.settings()[0];
+
+        if (settings.oScroll) {
+            settings.oScroll.sY = heightValue;
+        }
+
+        var $scrollBody = $(dataTableInstance.table().container()).find('.dataTables_scrollBody');
+        if ($scrollBody.length) {
+            $scrollBody.css({
+                'max-height': heightValue,
+                'height': heightValue
+            });
+        }
+
+        dataTableInstance.columns.adjust();
+        applyTableScale();
+    }
+
+    function scheduleTableSizing() {
+        if (typeof window !== 'undefined' && window.requestAnimationFrame) {
+            window.requestAnimationFrame(applyTableSizing);
+        } else {
+            setTimeout(applyTableSizing, 0);
+        }
+    }
+
+    function registerResizeHandler() {
+        $(window).off('resize.tableController').on('resize.tableController', function() {
+            if (resizeTimer) {
+                clearTimeout(resizeTimer);
+            }
+
+            resizeTimer = setTimeout(function() {
+                scheduleTableSizing();
+            }, 100);
+        });
+    }
+
     function init() {
         var tableData = PlatformModel.getPlatformData();
 
         // Initialize table with DataTables library
-        var table = $('#platformTable').DataTable({
+        dataTableInstance = $('#platformTable').DataTable({
             data: tableData,
             columns: [
                 { title: "Name", data: "platform_name" },
@@ -34,25 +193,37 @@ var TableController = (function() {
                 { title: "Subgroup", data: function(row) {
                     return row.subgroups && row.subgroups.length > 0 ? row.subgroups[0] : "";
                 }},
-                { 
-                    title: "Lat", 
+                {
+                    title: "Lat",
                     data: function(row) {
                         return parseFloat(row.latitude).toFixed(3);
-                    } 
+                    }
                 },
-                { 
-                    title: "Lon", 
+                {
+                    title: "Lon",
                     data: function(row) {
                         return parseFloat(row.longitude).toFixed(3);
-                    } 
+                    }
                 },
                 { title: "Alt", data: "altitude" }
-            ]
+            ],
+            scrollY: calculateTableHeight(),
+            scrollCollapse: true,
+            paging: false,
+            deferRender: true
         });
+
+        registerResizeHandler();
+
+        dataTableInstance.on('draw', function() {
+            scheduleTableSizing();
+        });
+
+        scheduleTableSizing();
 
         // Handle double-click on table rows
         $('#platformTable tbody').on('dblclick', 'tr', function() {
-            var rowData = table.row(this).data();
+            var rowData = dataTableInstance.row(this).data();
             var platform = PlatformModel.getPlatformData().find(function(p) {
                 return p.platform_name === rowData.platform_name;
             });
@@ -64,20 +235,20 @@ var TableController = (function() {
         // Handle shift-click on table rows
         $('#platformTable tbody').on('click', 'tr', function(event) {
             if (event.shiftKey) {
-                var rowData = table.row(this).data();
+                var rowData = dataTableInstance.row(this).data();
                 var platform = PlatformModel.getPlatformData().find(function(p) {
                     return p.platform_name === rowData.platform_name;
-                });  
+                });
                 if (platform) {
                     View.addPlatformToSelected(platform.platform_name);
-                }          
+                }
             }
         });
 
         // Handle ctrl-click on table rows
         $('#platformTable tbody').on('click', 'tr', function(event) {
             if (event.ctrlKey) {
-                var rowData = table.row(this).data();
+                var rowData = dataTableInstance.row(this).data();
                 var platform = PlatformModel.getPlatformData().find(function(p) {
                     return p.platform_name === rowData.platform_name;
                 });
@@ -91,13 +262,17 @@ var TableController = (function() {
 
     // Function to redraw the table with the latest platform data
     function redrawTable() {
-        var table = $('#platformTable').DataTable();          // platform table
-        var platModel = PlatformModel.getPlatformData();      // platform data    
-        table.clear();                                        // Clear existing data
-        table.rows.add(platModel);                            // Add new data
-        table.draw();                                         // Redraw the table
+        if (!dataTableInstance) {
+            return;
+        }
+
+        var platModel = PlatformModel.getPlatformData();      // platform data
+        dataTableInstance.clear();                             // Clear existing data
+        dataTableInstance.rows.add(platModel);                 // Add new data
+        dataTableInstance.draw();                              // Redraw the table
+        scheduleTableSizing();
     }
-    
+
     return {
         init: init,
         redrawTable: redrawTable


### PR DESCRIPTION
## Summary
- rework the platform table container styling so the DataTables wrapper flexes to consume the available viewport height
- update the table controller to compute the available space and resize the DataTables scroll area on window resizes and redraws
- disable pagination so the table content can scroll within the dynamically sized viewport-aligned region
- dynamically scale platform table fonts, padding, and line heights based on the available width so all columns fit without overflowing the viewport

## Testing
- Manual UI verification

------
https://chatgpt.com/codex/tasks/task_e_68de8d6b30d4832abf29085e5305453c