### PR TITLE
Add MapSettings configuration for Leaflet map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,40 @@
 # walt
 
 https://quasimodo12.github.io/walt/
+
+## Configuring map behavior
+
+The application exposes a global `MapSettings` object (defined in `js/config/map_settings.js`)
+that captures the initial Leaflet map options, base tile layer configuration, and ruler units.
+Scenario owners can override any of these values without touching the shared application logic.
+
+To override settings, define `window.MapSettings` **before** `js/config/map_settings.js` is
+loaded. Only the properties you provide will replace the defaults. For example:
+
+```html
+<script>
+  window.MapSettings = {
+    map: {
+      center: [35.0, -120.0],
+      zoom: 6,
+      maxBounds: null
+    },
+    tileLayer: {
+      url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      options: {
+        maxZoom: 19
+      }
+    },
+    ruler: {
+      lengthUnit: {
+        display: 'Kilometers',
+        factor: 1
+      }
+    }
+  };
+</script>
+<script src="js/config/map_settings.js"></script>
+```
+
+This pattern keeps scenario-specific map behavior in configuration while preserving the shared
+application logic in `js/view.js` and related modules.

--- a/index.html
+++ b/index.html
@@ -140,6 +140,7 @@
   <script src="js/export_laydown.js"></script>
   <script src="js/map_tools/map_tools_menu.js"></script>
   <script src="js/menu/main_menu_button_layout.js"></script>
+  <script src="js/config/map_settings.js"></script>
   <script src="js/view.js"></script>
 
 

--- a/js/config/map_settings.js
+++ b/js/config/map_settings.js
@@ -1,0 +1,69 @@
+// js/config/map_settings.js
+// Provides a global MapSettings object with default configuration values
+// for the map, tile layers, and measurement ruler.
+(function (global) {
+    function isPlainObject(value) {
+        return value !== null && typeof value === 'object' && !Array.isArray(value);
+    }
+
+    function mergeDeep(target, source) {
+        var output = Object.assign({}, target);
+
+        if (!isPlainObject(source)) {
+            return output;
+        }
+
+        Object.keys(source).forEach(function (key) {
+            var sourceValue = source[key];
+
+            if (isPlainObject(sourceValue)) {
+                var targetValue = output[key];
+                output[key] = mergeDeep(isPlainObject(targetValue) ? targetValue : {}, sourceValue);
+            } else {
+                output[key] = sourceValue;
+            }
+        });
+
+        return output;
+    }
+
+    var defaults = {
+        map: {
+            center: [0, 0],
+            zoom: 2,
+            minZoom: 2,
+            maxZoom: 22,
+            maxBounds: [
+                [-90, -180],
+                [90, 180]
+            ],
+            maxBoundsViscosity: 1.0,
+            boxZoom: false,
+            zoomAnimation: true,
+            fadeAnimation: true
+        },
+        tileLayer: {
+            url: 'tiles/{z}/{x}/{y}.png',
+            options: {
+                maxNativeZoom: 2,
+                minZoom: 2,
+                maxZoom: 22,
+                noWrap: true,
+                updateWhenZooming: true,
+                keepBuffer: 8,
+                detectRetina: false
+            }
+        },
+        ruler: {
+            position: 'topleft',
+            lengthUnit: {
+                label: 'Distance:',
+                factor: 0.539956803,
+                display: 'Nautical Miles',
+                decimal: 2
+            }
+        }
+    };
+
+    global.MapSettings = mergeDeep(defaults, global.MapSettings || {});
+})(window);

--- a/js/view.js
+++ b/js/view.js
@@ -8,42 +8,67 @@ var View = (function() {
 
     // Initialize the map with boxZoom disabled
     function initializeMap() {
-        map = L.map('map', {
-            center: [0, 0], // Set the initial center of the map
-            zoom: 2,        // Set the initial zoom level
-            minZoom: 2,     // Set the minimum zoom level
-            maxZoom: 22,    // Set the maximum zoom level
+        var settings = window.MapSettings || {};
+
+        var mapDefaults = {
+            center: [0, 0],
+            zoom: 2,
+            minZoom: 2,
+            maxZoom: 22,
             maxBounds: [
                 [-90, -180],
                 [90, 180]
             ],
             maxBoundsViscosity: 1.0,
-            boxZoom: false, // Disable the shift-click drag-to-zoom feature
+            boxZoom: false,
             zoomAnimation: true,
             fadeAnimation: true
-        }).setView([0, 0], 2);
+        };
 
-        L.tileLayer('tiles/{z}/{x}/{y}.png', {
-            maxNativeZoom: 2,
-            minZoom: 2,
-            maxZoom: 22,
-            noWrap: true, // Disable wrapping of tiles horizontally
-            updateWhenZooming: true,
-            keepBuffer: 8,
-            detectRetina: false
-        }).addTo(map);
+        var mapConfig = settings.map || {};
+        var mapOptions = Object.assign({}, mapDefaults, mapConfig);
+        var mapCenter = Array.isArray(mapConfig.center) ? mapConfig.center : mapDefaults.center;
+        var mapZoom = typeof mapConfig.zoom === 'number' ? mapConfig.zoom : mapDefaults.zoom;
+        mapOptions.center = mapCenter;
+        mapOptions.zoom = mapZoom;
+
+        map = L.map('map', mapOptions).setView(mapCenter, mapZoom);
+
+        var tileLayerDefaults = {
+            url: 'tiles/{z}/{x}/{y}.png',
+            options: {
+                maxNativeZoom: 2,
+                minZoom: 2,
+                maxZoom: 22,
+                noWrap: true,
+                updateWhenZooming: true,
+                keepBuffer: 8,
+                detectRetina: false
+            }
+        };
+
+        var tileLayerConfig = settings.tileLayer || {};
+        var tileLayerUrl = tileLayerConfig.url || tileLayerDefaults.url;
+        var tileLayerOptions = Object.assign({}, tileLayerDefaults.options, tileLayerConfig.options || {});
+
+        L.tileLayer(tileLayerUrl, tileLayerOptions).addTo(map);
 
         // Add the ruler to the map
-        var options = {
+        var rulerDefaults = {
             position: 'topleft',
             lengthUnit: {
                 label: 'Distance:',
-                factor: 0.539956803, // Convert from kilometers to nautical miles
+                factor: 0.539956803,
                 display: 'Nautical Miles',
-                decimal: 2,
-            },
+                decimal: 2
+            }
         };
-        L.control.ruler(options).addTo(map);
+
+        var rulerConfig = settings.ruler || {};
+        var rulerOptions = Object.assign({}, rulerDefaults, rulerConfig);
+        rulerOptions.lengthUnit = Object.assign({}, rulerDefaults.lengthUnit, rulerConfig.lengthUnit || {});
+
+        L.control.ruler(rulerOptions).addTo(map);
 
         // Initialize the dynamic map tools menu
         MapToolsMenu.init({ map: map });


### PR DESCRIPTION
## Summary
- add a MapSettings configuration module that supplies default map, tile, and ruler options
- load the configuration before view.js and refactor initializeMap to read from MapSettings with sensible fallbacks
- document how scenario owners can override MapSettings without editing application logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3e58a8020832ab4a6e9a9521719c6