### PR TITLE
Introduce shared side configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,45 @@ loaded. Only the properties you provide will replace the defaults. For example:
 
 This pattern keeps scenario-specific map behavior in configuration while preserving the shared
 application logic in `js/view.js` and related modules.
+
+## Configuring side definitions
+
+Global side metadata is defined in `js/config/side_config.js`. The file exposes a `SideConfig`
+helper that lists every supported side, its human-readable label, icon, display color, and the
+default opposing side. By default the tool ships with Blue and Red entries, but scenarios can
+override or extend this list without modifying the shared source.
+
+To customize the available sides, define `window.SideSettings` before the script is loaded. Each
+entry in `SideSettings.sides` must include an `id`, optional `label`, optional `defaultOpponent`,
+and any icon/color overrides you need:
+
+```html
+<script>
+  window.SideSettings = {
+    defaultSideId: 'coalition',
+    fallbackIconUrl: 'images/coalition-plat.png',
+    fallbackColor: '#999999',
+    sides: [
+      {
+        id: 'coalition',
+        label: 'Coalition',
+        defaultOpponent: 'adversary',
+        iconUrl: 'images/coalition-plat.png',
+        color: '#1F77B4'
+      },
+      {
+        id: 'adversary',
+        label: 'Adversary',
+        defaultOpponent: 'coalition',
+        iconUrl: 'images/adversary-plat.png',
+        color: '#D62728'
+      }
+    ]
+  };
+</script>
+<script src="js/config/side_config.js"></script>
+```
+
+Scripts that render dropdowns, map icons, range rings, or results views consume this shared
+configuration. If a platform, weapon, or sensor references a side that is not defined, the UI falls
+back to the configured default icon and a neutral color so undefined sides are still displayed.

--- a/index.html
+++ b/index.html
@@ -140,6 +140,7 @@
   <script src="js/export_laydown.js"></script>
   <script src="js/map_tools/map_tools_menu.js"></script>
   <script src="js/menu/main_menu_button_layout.js"></script>
+  <script src="js/config/side_config.js"></script>
   <script src="js/config/map_settings.js"></script>
   <script src="js/view.js"></script>
 

--- a/js/config/side_config.js
+++ b/js/config/side_config.js
@@ -1,0 +1,161 @@
+(function(global) {
+    'use strict';
+
+    var FALLBACK_SIDES = [
+        {
+            id: 'blue',
+            label: 'Blue',
+            defaultOpponent: 'red',
+            iconUrl: 'images/blue-plat.png',
+            color: '#36A2EB'
+        },
+        {
+            id: 'red',
+            label: 'Red',
+            defaultOpponent: 'blue',
+            iconUrl: 'images/red-plat.png',
+            color: '#FF944D'
+        }
+    ];
+
+    var FALLBACK_DEFAULT_SIDE_ID = 'blue';
+    var FALLBACK_ICON_URL = 'images/blue-plat.png';
+    var FALLBACK_COLOR = '#808080';
+
+    function normalizeSide(rawSide) {
+        if (!rawSide || typeof rawSide !== 'object') {
+            return null;
+        }
+
+        var id = typeof rawSide.id === 'string' ? rawSide.id.trim() : '';
+        if (!id) {
+            return null;
+        }
+
+        return {
+            id: id,
+            label: typeof rawSide.label === 'string' && rawSide.label.trim().length > 0
+                ? rawSide.label.trim()
+                : capitalize(id),
+            defaultOpponent: typeof rawSide.defaultOpponent === 'string' && rawSide.defaultOpponent.trim().length > 0
+                ? rawSide.defaultOpponent.trim()
+                : null,
+            iconUrl: typeof rawSide.iconUrl === 'string' && rawSide.iconUrl.trim().length > 0
+                ? rawSide.iconUrl.trim()
+                : null,
+            color: typeof rawSide.color === 'string' && rawSide.color.trim().length > 0
+                ? rawSide.color.trim()
+                : null
+        };
+    }
+
+    function capitalize(value) {
+        if (typeof value !== 'string' || value.length === 0) {
+            return '';
+        }
+        return value.charAt(0).toUpperCase() + value.slice(1);
+    }
+
+    function mapById(list) {
+        return list.reduce(function(acc, side) {
+            acc[side.id] = side;
+            return acc;
+        }, {});
+    }
+
+    var overrides = global.SideSettings || {};
+    var overrideSides = Array.isArray(overrides.sides)
+        ? overrides.sides.map(normalizeSide).filter(Boolean)
+        : [];
+    var sides = overrideSides.length > 0 ? overrideSides : FALLBACK_SIDES.map(normalizeSide).filter(Boolean);
+
+    var defaultSideId = typeof overrides.defaultSideId === 'string' && overrides.defaultSideId.trim().length > 0
+        ? overrides.defaultSideId.trim()
+        : FALLBACK_DEFAULT_SIDE_ID;
+
+    var fallbackIconUrl = typeof overrides.fallbackIconUrl === 'string' && overrides.fallbackIconUrl.trim().length > 0
+        ? overrides.fallbackIconUrl.trim()
+        : FALLBACK_ICON_URL;
+
+    var fallbackColor = typeof overrides.fallbackColor === 'string' && overrides.fallbackColor.trim().length > 0
+        ? overrides.fallbackColor.trim()
+        : FALLBACK_COLOR;
+
+    var sideMap = mapById(sides);
+
+    function getSides() {
+        return sides.map(function(side) {
+            return Object.assign({}, side);
+        });
+    }
+
+    function getSideById(id) {
+        if (typeof id !== 'string') {
+            return null;
+        }
+        return sideMap[id] || null;
+    }
+
+    function getDefaultSide() {
+        if (sideMap[defaultSideId]) {
+            return defaultSideId;
+        }
+        return sides.length > 0 ? sides[0].id : null;
+    }
+
+    function getDefaultOpponent(sideId) {
+        var side = getSideById(sideId);
+        if (side && side.defaultOpponent && sideMap[side.defaultOpponent]) {
+            return side.defaultOpponent;
+        }
+        var fallback = sides.find(function(candidate) {
+            return candidate.id !== sideId;
+        });
+        return fallback ? fallback.id : getDefaultSide();
+    }
+
+    function getLabelForSide(id) {
+        if (typeof id !== 'string') {
+            return '';
+        }
+        var side = getSideById(id);
+        if (side && side.label) {
+            return side.label;
+        }
+        return capitalize(id);
+    }
+
+    function getIconForSide(id) {
+        var side = getSideById(id);
+        if (side && side.iconUrl) {
+            return side.iconUrl;
+        }
+        return fallbackIconUrl;
+    }
+
+    function getColorForSide(id) {
+        var side = getSideById(id);
+        if (side && side.color) {
+            return side.color;
+        }
+        return fallbackColor;
+    }
+
+    function getAllSideIds() {
+        return sides.map(function(side) {
+            return side.id;
+        });
+    }
+
+    global.SideConfig = {
+        getSides: getSides,
+        getSideById: getSideById,
+        getDefaultSide: getDefaultSide,
+        getDefaultOpponent: getDefaultOpponent,
+        getLabelForSide: getLabelForSide,
+        getIconForSide: getIconForSide,
+        getColorForSide: getColorForSide,
+        getAllSideIds: getAllSideIds
+    };
+
+})(window);

--- a/js/platforms/create_plat_config.js
+++ b/js/platforms/create_plat_config.js
@@ -1,8 +1,63 @@
 // create_plat_config.js
 var CreatePlatConfig = (function () {
 
+    function getConfiguredSides() {
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getSides === 'function') {
+            var configuredSides = SideConfig.getSides();
+            if (Array.isArray(configuredSides) && configuredSides.length > 0) {
+                return configuredSides;
+            }
+        }
+        return [
+            { id: 'blue', label: 'Blue' },
+            { id: 'red', label: 'Red' }
+        ];
+    }
+
+    function getDefaultSideId() {
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getDefaultSide === 'function') {
+            var defaultId = SideConfig.getDefaultSide();
+            if (defaultId) {
+                return defaultId;
+            }
+        }
+        var sides = getConfiguredSides();
+        return sides.length > 0 ? sides[0].id : '';
+    }
+
+    function getLabelForSide(sideId) {
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getLabelForSide === 'function') {
+            var label = SideConfig.getLabelForSide(sideId);
+            if (label) {
+                return label;
+            }
+        }
+        return sideId || '';
+    }
+
+    function buildSideOptions(selectedSideId) {
+        var sides = getConfiguredSides();
+        var selectedId = selectedSideId || getDefaultSideId();
+        var hasSelected = false;
+
+        var optionsHtml = sides.map(function(side) {
+            var isSelected = side.id === selectedId;
+            if (isSelected) {
+                hasSelected = true;
+            }
+            return '<option value="' + side.id + '" ' + (isSelected ? 'selected' : '') + '>' + side.label + '</option>';
+        }).join('');
+
+        if (!hasSelected && selectedId) {
+            optionsHtml += '<option value="' + selectedId + '" selected>' + getLabelForSide(selectedId) + '</option>';
+        }
+
+        return optionsHtml;
+    }
+
     // Function to create the platform creation dialog
     function createPlatConfigDialog() {
+        var sideOptions = buildSideOptions();
         // HTML content for the dialog
         var content = `
             <div>
@@ -15,8 +70,7 @@ var CreatePlatConfig = (function () {
                         <td><label for="side">Side:</label></td>
                         <td>
                             <select id="side">
-                                <option value="blue">Blue</option>
-                                <option value="red">Red</option>
+                                ${sideOptions}
                             </select>
                         </td>
                     </tr>
@@ -72,7 +126,7 @@ var CreatePlatConfig = (function () {
         $('#createPlatformContent').off('click', '#createPlatformButton').on('click', '#createPlatformButton', function() {
             console.log('Create Platform button clicked');
             var platformName = ($('#platformName').val() || '').trim();
-            var side = $('#side').val();
+            var side = $('#side').val() || getDefaultSideId();
             var group = ($('#group').val() || '').trim();
             var category = ($('#category').val() || '').trim();
             var type = ($('#type').val() || '').trim();
@@ -93,7 +147,7 @@ var CreatePlatConfig = (function () {
 
             // Check if the new name already exists (excluding the current platform's name)
             var nameExists = platformData.some(function(existingPlatform) {
-                return existingPlatform.platform_name === newName && existingPlatform.platform_name !== platform.platform_name;
+                return existingPlatform.platform_name === newName;
             });
 
             if (nameExists) {

--- a/js/platforms/plat_config.js
+++ b/js/platforms/plat_config.js
@@ -1,8 +1,59 @@
 // plat_config.js
 var PlatformConfig = (function() {
 
+    function getConfiguredSides() {
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getSides === 'function') {
+            var configuredSides = SideConfig.getSides();
+            if (Array.isArray(configuredSides) && configuredSides.length > 0) {
+                return configuredSides;
+            }
+        }
+        return [
+            { id: 'blue', label: 'Blue' },
+            { id: 'red', label: 'Red' }
+        ];
+    }
+
+    function getDefaultSideId() {
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getDefaultSide === 'function') {
+            return SideConfig.getDefaultSide();
+        }
+        return getConfiguredSides()[0].id;
+    }
+
+    function getLabelForSide(sideId) {
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getLabelForSide === 'function') {
+            var label = SideConfig.getLabelForSide(sideId);
+            if (label) {
+                return label;
+            }
+        }
+        return sideId;
+    }
+
+    function buildSideOptions(selectedSideId) {
+        var sides = getConfiguredSides();
+        var selectedId = selectedSideId || getDefaultSideId();
+        var hasSelected = false;
+
+        var optionsHtml = sides.map(function(side) {
+            var isSelected = side.id === selectedId;
+            if (isSelected) {
+                hasSelected = true;
+            }
+            return '<option value="' + side.id + '" ' + (isSelected ? 'selected' : '') + '>' + side.label + '</option>';
+        }).join('');
+
+        if (!hasSelected && selectedId) {
+            optionsHtml += '<option value="' + selectedId + '" selected>' + getLabelForSide(selectedId) + '</option>';
+        }
+
+        return optionsHtml;
+    }
+
     // Function to create platform info dialog with inputs
     function createPlatformDialog(platform) {
+        var sideOptions = buildSideOptions(platform && platform.side);
         // Create the HTML content for the platform dialog
         var content = `
         <style>
@@ -100,8 +151,7 @@ var PlatformConfig = (function() {
                             <td><label for="platformSideInput"><strong>Side:</strong></label></td>
                             <td>
                                 <select id="platformSideInput" class="full-width">
-                                    <option value="blue" ${platform.side === 'blue' ? 'selected' : ''}>Blue</option>
-                                    <option value="red" ${platform.side === 'red' ? 'selected' : ''}>Red</option>
+                                    ${sideOptions}
                                 </select>
                             </td>
                         </tr>

--- a/js/range_rings/range_ring_logic.js
+++ b/js/range_rings/range_ring_logic.js
@@ -38,7 +38,14 @@ var RangeRingLogic = (function() {
       .forEach(function(rangeRing) {
         // Determine the side and corresponding color
         var side = platformSideLookup[rangeRing.platform_name];
-        var color = side === 'blue' ? 'blue' : (side === 'red' ? 'red' : 'gray');
+        var color = '#808080';
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getColorForSide === 'function') {
+          color = SideConfig.getColorForSide(side);
+        } else if (side === 'blue') {
+          color = 'blue';
+        } else if (side === 'red') {
+          color = 'red';
+        }
 
         // Define the circle using Leaflet's L.circle function
         var circle = L.circle([rangeRing.latitude, rangeRing.longitude], {

--- a/js/sensors/sensor_config.js
+++ b/js/sensors/sensor_config.js
@@ -1,6 +1,60 @@
 // Updated sensor_config.js
 var SensorConfig = (function() {
 
+    function getConfiguredSides() {
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getSides === 'function') {
+            var configuredSides = SideConfig.getSides();
+            if (Array.isArray(configuredSides) && configuredSides.length > 0) {
+                return configuredSides;
+            }
+        }
+        return [
+            { id: 'blue', label: 'Blue' },
+            { id: 'red', label: 'Red' }
+        ];
+    }
+
+    function getDefaultSideId() {
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getDefaultSide === 'function') {
+            var defaultId = SideConfig.getDefaultSide();
+            if (defaultId) {
+                return defaultId;
+            }
+        }
+        var sides = getConfiguredSides();
+        return sides.length > 0 ? sides[0].id : '';
+    }
+
+    function getLabelForSide(sideId) {
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getLabelForSide === 'function') {
+            var label = SideConfig.getLabelForSide(sideId);
+            if (label) {
+                return label;
+            }
+        }
+        return sideId || '';
+    }
+
+    function buildSideOptions(selectedSideId) {
+        var sides = getConfiguredSides();
+        var selectedId = selectedSideId || getDefaultSideId();
+        var hasSelected = false;
+
+        var optionsHtml = sides.map(function(side) {
+            var isSelected = side.id === selectedId;
+            if (isSelected) {
+                hasSelected = true;
+            }
+            return '<option value="' + side.id + '" ' + (isSelected ? 'selected' : '') + '>' + side.label + '</option>';
+        }).join('');
+
+        if (!hasSelected && selectedId) {
+            optionsHtml += '<option value="' + selectedId + '" selected>' + getLabelForSide(selectedId) + '</option>';
+        }
+
+        return optionsHtml;
+    }
+
     // Function to create platform info dialog with inputs
     function createSensorConfigDialog() {
         var sensorData = SensorStorage.getSensorData();
@@ -15,11 +69,11 @@ var SensorConfig = (function() {
 
         // Populate the table with sensor data
         sensorData.forEach(function(sensor, index) {
+            var sideOptions = buildSideOptions(sensor && sensor.side);
             content += '<tr>' +
                 '<td><input type="text" value="' + sensor.sensor_name + '" class="sensor-name" data-index="' + index + '" /></td>' +
                 '<td><select class="sensor-side" data-index="' + index + '">' +
-                '<option value="blue" ' + (sensor.side === 'blue' ? 'selected' : '') + '>Blue</option>' +
-                '<option value="red" ' + (sensor.side === 'red' ? 'selected' : '') + '>Red</option>' +
+                sideOptions +
                 '</select></td>' +
                 '<td><input type="number" value="' + sensor.sensor_range + '" class="sensor-range" data-index="' + index + '" /></td>' +
                 '<td><button class="delete-sensor" data-index="' + index + '">Delete</button></td>' +
@@ -59,7 +113,7 @@ var SensorConfig = (function() {
         $(allRows).each(function() {
             var index = $(this).find('.sensor-name').data('index');
             var name = $(this).find('.sensor-name').val().trim();
-            var side = $(this).find('.sensor-side').val();
+            var side = $(this).find('.sensor-side').val() || getDefaultSideId();
             var range = parseInt($(this).find('.sensor-range').val(), 10);
         
             // Save old name for updating platformData
@@ -157,7 +211,7 @@ var SensorConfig = (function() {
                 return;
             }
 
-            addSensorToStorage(sensorName, 'blue', 0);
+            addSensorToStorage(sensorName, getDefaultSideId(), 0);
             $('#addSensorDialogContent').dialog('close');
             createSensorConfigDialog();
         });
@@ -169,7 +223,7 @@ var SensorConfig = (function() {
         } else if (isUniqueSensorName(name)) {
             SensorStorage.getSensorData().push({
                 sensor_name: name,
-                side: side,
+                side: side || getDefaultSideId(),
                 sensor_range: maxRange
             });
         } else {

--- a/js/view.js
+++ b/js/view.js
@@ -320,7 +320,12 @@ var View = (function() {
      * @returns {Array} - A new array where each element is a formatted string representing a platform.
      */
     function createCustomIcon(side) {
-        var iconUrl = (side === "blue") ? 'images/blue-plat.png' : 'images/red-plat.png';
+        var iconUrl = 'images/blue-plat.png';
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getIconForSide === 'function') {
+            iconUrl = SideConfig.getIconForSide(side);
+        } else if (typeof side === 'string') {
+            iconUrl = side === 'red' ? 'images/red-plat.png' : 'images/blue-plat.png';
+        }
         return L.icon({
             iconUrl: iconUrl,
             iconSize: [24, 24], // Customize the size of the icon

--- a/js/weapons/weapon_config.js
+++ b/js/weapons/weapon_config.js
@@ -1,6 +1,60 @@
 // weapon_config.js
 var WeaponConfig = (function() {
 
+    function getConfiguredSides() {
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getSides === 'function') {
+            var configuredSides = SideConfig.getSides();
+            if (Array.isArray(configuredSides) && configuredSides.length > 0) {
+                return configuredSides;
+            }
+        }
+        return [
+            { id: 'blue', label: 'Blue' },
+            { id: 'red', label: 'Red' }
+        ];
+    }
+
+    function getDefaultSideId() {
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getDefaultSide === 'function') {
+            var defaultId = SideConfig.getDefaultSide();
+            if (defaultId) {
+                return defaultId;
+            }
+        }
+        var sides = getConfiguredSides();
+        return sides.length > 0 ? sides[0].id : '';
+    }
+
+    function getLabelForSide(sideId) {
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getLabelForSide === 'function') {
+            var label = SideConfig.getLabelForSide(sideId);
+            if (label) {
+                return label;
+            }
+        }
+        return sideId || '';
+    }
+
+    function buildSideOptions(selectedSideId) {
+        var sides = getConfiguredSides();
+        var selectedId = selectedSideId || getDefaultSideId();
+        var hasSelected = false;
+
+        var optionsHtml = sides.map(function(side) {
+            var isSelected = side.id === selectedId;
+            if (isSelected) {
+                hasSelected = true;
+            }
+            return '<option value="' + side.id + '" ' + (isSelected ? 'selected' : '') + '>' + side.label + '</option>';
+        }).join('');
+
+        if (!hasSelected && selectedId) {
+            optionsHtml += '<option value="' + selectedId + '" selected>' + getLabelForSide(selectedId) + '</option>';
+        }
+
+        return optionsHtml;
+    }
+
     // Function to create platform info dialog with inputs
     function createWeaponConfigDialog() {
         var weaponData = WeaponStorage.getWeaponData();
@@ -15,11 +69,11 @@ var WeaponConfig = (function() {
 
         // Populate the table with weapon data
         weaponData.forEach(function(weapon, index) {
+            var sideOptions = buildSideOptions(weapon && weapon.side);
             content += '<tr>' +
                 '<td><input type="text" value="' + weapon.weapon_name + '" class="weapon-name" data-index="' + index + '" /></td>' +
                 '<td><select class="weapon-side" data-index="' + index + '">' +
-                '<option value="blue" ' + (weapon.side === 'blue' ? 'selected' : '') + '>Blue</option>' +
-                '<option value="red" ' + (weapon.side === 'red' ? 'selected' : '') + '>Red</option>' +
+                sideOptions +
                 '</select></td>' +
                 '<td><input type="number" value="' + weapon.weapon_range + '" class="weapon-range" data-index="' + index + '" /></td>' +
                 '<td><button class="delete-weapon" data-index="' + index + '">Delete</button></td>' +
@@ -59,7 +113,7 @@ var WeaponConfig = (function() {
         $(allRows).each(function() {
             var index = $(this).find('.weapon-name').data('index');
             var name = $(this).find('.weapon-name').val().trim();
-            var side = $(this).find('.weapon-side').val();
+            var side = $(this).find('.weapon-side').val() || getDefaultSideId();
             var range = parseInt($(this).find('.weapon-range').val(), 10);
         
             // Save old name for updating platformData
@@ -126,7 +180,7 @@ var WeaponConfig = (function() {
         } else if (isUniqueWeaponName(name)) {
             WeaponStorage.getWeaponData().push({
                 weapon_name: name,
-                side: side,
+                side: side || getDefaultSideId(),
                 weapon_range: maxRange
             });
         } else {
@@ -178,7 +232,7 @@ var WeaponConfig = (function() {
             }
     
             // Add weapon to storage with default values for side and range
-            addWeaponToStorage(weaponName, 'blue', 0);
+            addWeaponToStorage(weaponName, getDefaultSideId(), 0);
     
             // Close dialog and refresh the main weapon config dialog
             $('#addWeaponDialogContent').dialog('close');

--- a/results.html
+++ b/results.html
@@ -55,6 +55,7 @@
         eruda.init();
     </script>
 
+    <script src="js/config/side_config.js"></script>
     <!-- Custom JavaScript Files -->
     <script src="results/js/globals.js"></script>
     <script src="results/js/utils.js"></script>

--- a/results/js/charts.js
+++ b/results/js/charts.js
@@ -14,6 +14,29 @@
  * @param {string} wName - weapon name to count
  * @returns {number}
  */
+function getSideColor(sideId, fallbackColor) {
+    if (typeof SideConfig !== 'undefined' && typeof SideConfig.getColorForSide === 'function') {
+        const color = SideConfig.getColorForSide(sideId);
+        if (color) {
+            return color;
+        }
+    }
+    return fallbackColor;
+}
+
+function getSideLabelOrFallback(sideId, fallbackLabel) {
+    if (typeof SideConfig !== 'undefined' && typeof SideConfig.getLabelForSide === 'function') {
+        const label = SideConfig.getLabelForSide(sideId);
+        if (label) {
+            return label;
+        }
+    }
+    if (sideId) {
+        return capitalize(sideId);
+    }
+    return fallbackLabel || '';
+}
+
 function getTotalWeaponQuantity(pData, pNames, wName) {
     console.log("results.js >>> getTotalWeaponQuantity() entered");
     let totalQuantity = 0;
@@ -195,7 +218,9 @@ function processItems(itemList, itemType) {
             console.log(`Percentage of enemies in range for ${itemType} ${itemName} in group ${group}: ${percentageInRange}%`);
             console.log(`Percentage of enemies out of range for ${itemType} ${itemName} in group ${group}: ${percentageOutOfRange}%`);
 
-            const selectedColor = selectedSide === 'blue' ? '#36A2EB' : selectedSide === 'red' ? '#ff944d' : null;
+            const selectedColor = getSideColor(selectedSide, '#36A2EB');
+            const enemySideLabel = getSideLabelOrFallback(enemySide, 'Enemy');
+            const friendlyColor = getSideColor(selectedSide, '#4d94ff');
 
             const chartTypeDropdown = document.getElementById("chart-type");
             const selectedChartType = chartTypeDropdown.value;
@@ -253,22 +278,17 @@ function processItems(itemList, itemType) {
                     quantityBarPriority = 2;
                 }
 
-                if (selectedSide === 'blue') {
-                    wezBarColor = '#4d94ff';
-                }
-                else {
-                    wezBarColor = '#ff944d';
-                }
+                wezBarColor = friendlyColor;
 
                 const newBars = [
                     {
-                        barLabel: `${capitalize(enemySide)} Platforms in Group`,
+                        barLabel: `${enemySideLabel} Platforms in Group`,
                         barValue: numPlats,
                         barColor: '#a6a6a6',
                         barPriority: numPlatsBarPriority
                     },
                     {
-                        barLabel: `${capitalize(enemySide)} Platforms in WEZ`,
+                        barLabel: `${enemySideLabel} Platforms in WEZ`,
                         barValue: wez,
                         barColor: wezBarColor,
                         barPriority: wezBarPriority

--- a/results/js/config.js
+++ b/results/js/config.js
@@ -11,6 +11,66 @@
  * Populate all dropdowns in the configuration dialog based on the currently
  * loaded platform, weapon and sensor data.
  */
+function getConfiguredSides() {
+    if (typeof SideConfig !== 'undefined' && typeof SideConfig.getSides === 'function') {
+        const configuredSides = SideConfig.getSides();
+        if (Array.isArray(configuredSides) && configuredSides.length > 0) {
+            return configuredSides;
+        }
+    }
+    return [];
+}
+
+function getDefaultSideId() {
+    if (typeof SideConfig !== 'undefined' && typeof SideConfig.getDefaultSide === 'function') {
+        const defaultSide = SideConfig.getDefaultSide();
+        if (defaultSide) {
+            return defaultSide;
+        }
+    }
+    return null;
+}
+
+function getSideLabel(sideId) {
+    if (typeof SideConfig !== 'undefined' && typeof SideConfig.getLabelForSide === 'function') {
+        const label = SideConfig.getLabelForSide(sideId);
+        if (label) {
+            return label;
+        }
+    }
+    return sideId || '';
+}
+
+function determineEnemySide(selectedSide, platformSides) {
+    if (!selectedSide) {
+        return null;
+    }
+
+    let opponent = null;
+    if (typeof SideConfig !== 'undefined' && typeof SideConfig.getDefaultOpponent === 'function') {
+        opponent = SideConfig.getDefaultOpponent(selectedSide);
+        if (opponent === selectedSide) {
+            opponent = null;
+        }
+    }
+
+    const sideSet = platformSides instanceof Set ? platformSides : new Set();
+    if (sideSet.size > 0 && opponent && !sideSet.has(opponent)) {
+        opponent = null;
+    }
+
+    if (!opponent) {
+        for (const candidate of sideSet) {
+            if (candidate && candidate !== selectedSide) {
+                opponent = candidate;
+                break;
+            }
+        }
+    }
+
+    return opponent;
+}
+
 function populateConfigDropdowns() {
     const elements = {
         side: document.getElementById('side'),
@@ -28,31 +88,65 @@ function populateConfigDropdowns() {
     const sensorOptions = sensorData.map(s => s.sensor_name);
     populateDropdown(elements.sensors, sensorOptions);
 
-    const sideOptions = getUniqueValues(platformData, 'side');
-    populateDropdown(elements.side, sideOptions);
+    const platformSides = new Set(getUniqueValues(platformData, 'side').filter(Boolean));
+    const configuredSides = getConfiguredSides();
+    let availableSides = configuredSides.filter(side => platformSides.has(side.id));
 
-    selectedSide = elements.side.value;
+    if (availableSides.length === 0) {
+        availableSides = configuredSides.length > 0
+            ? configuredSides
+            : Array.from(platformSides).map(id => ({ id, label: getSideLabel(id) }));
+    }
+
+    populateDropdown(elements.side, availableSides.map(side => ({ value: side.id, label: side.label })));
+
+    const defaultSideId = getDefaultSideId();
+    const optionValues = Array.from(elements.side.options).map(opt => opt.value);
+    if (!elements.side.value) {
+        if (defaultSideId && optionValues.includes(defaultSideId)) {
+            elements.side.value = defaultSideId;
+        } else if (optionValues.length > 0) {
+            elements.side.value = optionValues[0];
+        }
+    }
+
+    selectedSide = elements.side.value || defaultSideId;
+    friendlySide = selectedSide;
 
     const friendlyPlatforms = platformData
-        .filter(p => p.side === selectedSide)
+        .filter(p => !selectedSide || p.side === selectedSide)
         .map(p => p.platform_name);
     populateDropdown(elements.friendlyPlatforms, friendlyPlatforms);
 
-    const friendlyGroups = getGroups(platformData, selectedSide);
+    const friendlyGroups = selectedSide ? getGroups(platformData, selectedSide) : [];
     populateDropdown(elements.friendlyGroups, friendlyGroups);
 
-    const enemyPlatforms = platformData
-        .filter(p => p.side !== selectedSide)
-        .map(p => p.platform_name);
+    const enemySideId = determineEnemySide(selectedSide, platformSides);
+    enemySide = enemySideId;
+
+    const enemyCandidates = platformData.filter(p => {
+        if (!selectedSide) {
+            return true;
+        }
+        if (enemySideId) {
+            return p.side === enemySideId;
+        }
+        return p.side !== selectedSide;
+    });
+
+    const enemyPlatforms = enemyCandidates.map(p => p.platform_name);
     populateDropdown(elements.enemyPlatforms, enemyPlatforms);
 
-    enemySide = selectedSide === 'blue' ? 'red' : 'blue';
-
-    const enemyGroups = getGroups(
-        platformData.filter(p => p.side === enemySide),
-        enemySide
-    );
-    populateDropdown(elements.enemyGroups, enemyGroups);
+    const enemyGroupsSet = new Set();
+    enemyCandidates.forEach(candidate => {
+        if (candidate.group) {
+            enemyGroupsSet.add(candidate.group);
+        }
+        if (Array.isArray(candidate.subgroups)) {
+            candidate.subgroups.forEach(subgroup => enemyGroupsSet.add(subgroup));
+        }
+    });
+    populateDropdown(elements.enemyGroups, Array.from(enemyGroupsSet));
 }
 
 /**
@@ -65,7 +159,15 @@ function applyConfig() {
         return Array.from(selectElement.selectedOptions).map(option => option.value);
     };
 
-    const selectedSide = document.getElementById('side').value;
+    const selectedSideDropdown = document.getElementById('side');
+    const selectedSide = (selectedSideDropdown && selectedSideDropdown.value) || getDefaultSideId();
+    if (selectedSideDropdown && selectedSide) {
+        selectedSideDropdown.value = selectedSide;
+    }
+
+    const platformSides = new Set(getUniqueValues(platformData, 'side').filter(Boolean));
+    friendlySide = selectedSide;
+    enemySide = determineEnemySide(selectedSide, platformSides);
 
     const selectedFriendlyGroups = getSelectedValues('friendly-groups');
     const selectedFriendlyPlatforms = getSelectedValues('friendly-platforms');

--- a/results/js/legend.js
+++ b/results/js/legend.js
@@ -35,16 +35,50 @@ function createLegend(divId, legendType, side) {
     var tbody = document.createElement('tbody');
 
     // Side-color-choice
-    var enemySideText = ''; 
-    var enemySideColor = '';
-    if (side === 'blue') {
-        enemySideText = 'Red';
-        enemySideColor = '#4d94ff';
+    function resolveSideLabel(sideId, fallback) {
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getLabelForSide === 'function') {
+            var label = SideConfig.getLabelForSide(sideId);
+            if (label) {
+                return label;
+            }
+        }
+        if (sideId) {
+            return sideId.charAt(0).toUpperCase() + sideId.slice(1);
+        }
+        return fallback;
     }
-    else {
-        enemySideText = 'Blue'
-        enemySideColor = '#ff944d';
+
+    function resolveSideColor(sideId, fallback) {
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getColorForSide === 'function') {
+            var color = SideConfig.getColorForSide(sideId);
+            if (color) {
+                return color;
+            }
+        }
+        return fallback;
     }
+
+    function resolveDefaultSide() {
+        if (typeof SideConfig !== 'undefined' && typeof SideConfig.getDefaultSide === 'function') {
+            var defaultSide = SideConfig.getDefaultSide();
+            if (defaultSide) {
+                return defaultSide;
+            }
+        }
+        return null;
+    }
+
+    var friendlySideId = side || resolveDefaultSide();
+    var enemySideId = null;
+    if (typeof SideConfig !== 'undefined' && typeof SideConfig.getDefaultOpponent === 'function') {
+        enemySideId = SideConfig.getDefaultOpponent(friendlySideId);
+        if (enemySideId === friendlySideId) {
+            enemySideId = null;
+        }
+    }
+
+    var enemySideText = resolveSideLabel(enemySideId, 'Enemy');
+    var enemySideColor = resolveSideColor(friendlySideId, '#4d94ff');
 
     if (legendType === 'Pie') {
         // Row 1: 'Side' Circle | "Percent of Platforms in WEZ"

--- a/results/js/utils.js
+++ b/results/js/utils.js
@@ -28,14 +28,42 @@ function arraysEqual(arr1, arr2) {
  * @param {string[]} newOptions
  */
 function populateDropdown(selectElement, newOptions) {
+    const normalized = (Array.isArray(newOptions) ? newOptions : []).map(option => {
+        if (typeof option === 'string') {
+            return { value: option, label: option };
+        }
+        if (option && typeof option === 'object') {
+            const value = typeof option.value === 'string' && option.value
+                ? option.value
+                : (typeof option.id === 'string' ? option.id : '');
+            if (!value) {
+                return null;
+            }
+            const label = typeof option.label === 'string' && option.label
+                ? option.label
+                : (typeof option.text === 'string' && option.text ? option.text : value);
+            return { value, label };
+        }
+        return null;
+    }).filter(Boolean);
+
+    const desiredValues = normalized.map(opt => opt.value);
     const currentOptions = Array.from(selectElement.options).map(opt => opt.value);
-    if (!arraysEqual(currentOptions, newOptions)) {
+
+    if (!arraysEqual(currentOptions, desiredValues)) {
         selectElement.innerHTML = '';
-        newOptions.forEach(value => {
-            const option = document.createElement('option');
-            option.value = value;
-            option.text = value;
-            selectElement.add(option);
+        normalized.forEach(opt => {
+            const optionElement = document.createElement('option');
+            optionElement.value = opt.value;
+            optionElement.text = opt.label;
+            selectElement.add(optionElement);
+        });
+    } else {
+        normalized.forEach((opt, index) => {
+            const existingOption = selectElement.options[index];
+            if (existingOption && existingOption.text !== opt.label) {
+                existingOption.text = opt.label;
+            }
         });
     }
 }


### PR DESCRIPTION
## Summary
- add a shared `SideConfig` module for icons, colors, and default opponent relationships and load it ahead of dependent scripts
- update platform, weapon, and sensor configuration dialogs along with map markers and range rings to read side options and fallbacks from the shared configuration
- refactor the results view to derive enemy mappings and chart colors from the shared side settings and document how to override side definitions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3e87b426c832a96593a60cafb7ff5