### PR TITLE
Allow main menu layout overrides via MainMenuSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,50 @@ loaded. Only the properties you provide will replace the defaults. For example:
 This pattern keeps scenario-specific map behavior in configuration while preserving the shared
 application logic in `js/view.js` and related modules.
 
+## Configuring the main menu layout
+
+The main menu buttons are rendered by `js/menu/main_menu_button_layout.js`. Scenarios can adjust
+the arrangement or target container by defining `window.MainMenuSettings` before that script is
+loaded. Only the supplied properties replace the defaults:
+
+```html
+<script>
+  window.MainMenuSettings = {
+    containerId: 'scenarioMenuContainer',
+    layout: [
+      [
+        { id: 'createPlatformButton', label: 'Add New Platform' },
+        { id: 'refreshDataButton', label: 'Refresh Data' }
+      ],
+      [
+        { id: 'openChartsButton', label: 'Display Results' }
+      ]
+    ]
+  };
+</script>
+<script src="js/menu/main_menu_button_layout.js"></script>
+```
+
+By default the module renders immediately using either the overridden layout or the built-in
+structure. To supply a layout later (for example, after fetching scenario data), set
+`autoRender: false` and invoke `MainMenuButtons.applyLayout(customLayout)` when ready:
+
+```html
+<script>
+  window.MainMenuSettings = {
+    autoRender: false
+  };
+</script>
+<script src="js/menu/main_menu_button_layout.js"></script>
+<script>
+  fetch('/scenario/menu-layout.json')
+    .then(function(response) { return response.json(); })
+    .then(function(customLayout) {
+      MainMenuButtons.applyLayout(customLayout);
+    });
+</script>
+```
+
 ## Configuring side definitions
 
 Global side metadata is defined in `js/config/side_config.js`. The file exposes a `SideConfig`

--- a/js/menu/main_menu_button_layout.js
+++ b/js/menu/main_menu_button_layout.js
@@ -1,7 +1,7 @@
 // js/menu/main_menu_button_layout.js
 // Creates the dynamic main menu button container based on a configurable layout
 
-var MainMenuButtons = (function() {
+var MainMenuButtons = (function(global) {
   /**
    * Default layout for the main menu buttons. Each array entry represents a row,
    * and every object inside the row describes an individual button. To change
@@ -26,7 +26,23 @@ var MainMenuButtons = (function() {
     ]
   ];
 
-  const CONTAINER_ID = 'mainMenuButtonContainer';
+  const DEFAULT_CONTAINER_ID = 'mainMenuButtonContainer';
+
+  function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+  }
+
+  const overrides = global.MainMenuSettings || {};
+  const hasLayoutOverride = Array.isArray(overrides.layout);
+  const containerOverrideProvided = isNonEmptyString(overrides.containerId);
+  const containerId = containerOverrideProvided ? overrides.containerId : DEFAULT_CONTAINER_ID;
+  const autoRender = overrides.autoRender !== false;
+
+  let currentLayout = hasLayoutOverride ? overrides.layout : defaultLayout;
+
+  function cloneLayout(layout) {
+    return JSON.parse(JSON.stringify(layout));
+  }
 
   /**
    * Builds a single button element based on the provided configuration.
@@ -62,7 +78,7 @@ var MainMenuButtons = (function() {
    * @param {Array<Array<Object>>} layout
    */
   function render(layout) {
-    const container = document.getElementById(CONTAINER_ID);
+    const container = document.getElementById(containerId);
     if (!container) {
       return;
     }
@@ -81,16 +97,35 @@ var MainMenuButtons = (function() {
     });
   }
 
+  function resolveLayout(layout) {
+    if (Array.isArray(layout)) {
+      currentLayout = layout;
+      return layout;
+    }
+
+    if (Array.isArray(currentLayout)) {
+      return currentLayout;
+    }
+
+    currentLayout = defaultLayout;
+    return currentLayout;
+  }
+
+  const shouldAutoRender = autoRender && (!global.MainMenuSettings || hasLayoutOverride || containerOverrideProvided);
+
+  if (shouldAutoRender) {
+    render(resolveLayout());
+  }
+
   return {
     applyLayout: function(layout) {
-      render(Array.isArray(layout) ? layout : defaultLayout);
+      render(resolveLayout(layout));
     },
     getDefaultLayout: function() {
-      return JSON.parse(JSON.stringify(defaultLayout));
+      return cloneLayout(defaultLayout);
+    },
+    getConfiguredLayout: function() {
+      return cloneLayout(resolveLayout());
     }
   };
-})();
-
-// Render the default layout immediately so that other scripts can attach
-// event listeners to the generated buttons.
-MainMenuButtons.applyLayout();
+})(window);


### PR DESCRIPTION
## Summary
- teach the main menu layout helper to read optional `window.MainMenuSettings` values for container, layout, and auto-render behavior
- avoid auto-render when callers disable it and expose helpers to inspect the configured layout
- document how scenarios can define `MainMenuSettings` before loading the script to customize button placement

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4f78c7d80832aa0da68af0ce252c1