### PR TITLE
Reduce main menu footprint and centralize layout configuration

### DIFF
--- a/css/walt-menu-styles.css
+++ b/css/walt-menu-styles.css
@@ -9,6 +9,22 @@
 
 */
 
+/* Layout variables for the main menu. Adjust these to change spacing and sizing.
+   They can also be overridden via js/config/main_menu_layout_config.js. */
+:root {
+  --main-menu-width: 30%;
+  --main-menu-padding: 16px;
+  --main-menu-content-gap: 12px;
+  --main-menu-header-gap: 6px;
+  --main-menu-toolbar-gap: 8px;
+  --main-menu-button-section-padding: 8px;
+  --main-menu-button-row-gap: 12px;
+  --main-menu-button-gap: 10px;
+  --main-menu-button-min-width: clamp(100px, 22%, 240px);
+  --main-menu-button-min-height: clamp(34px, 3.1vw, 64px);
+  --main-menu-button-font-size: clamp(0.78rem, 0.68vw + 0.55rem, 1.15rem);
+}
+
 /* ============================================= */
 /* Platform Table Container                      */
 /* ============================================= */
@@ -18,23 +34,23 @@
     --table-cell-padding: 10px;
     --table-line-height: 1.4;
     overflow: hidden;
-    width: 35%;
+    width: var(--main-menu-width);
     height: 100vh;
     float: right;
     display: flex;
     flex-direction: column;
-    padding: 20px;
+    padding: var(--main-menu-padding);
     box-sizing: border-box;
     border: 2px solid #ddd;
     background-color: #f9f9f9;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    gap: 16px;
+    gap: var(--main-menu-content-gap);
   }
 
 #platformTableContainer .platform-table-header {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: var(--main-menu-header-gap);
     flex: 0 0 auto;
 }
 
@@ -42,7 +58,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: 12px;
+    gap: var(--main-menu-toolbar-gap);
 }
 
 #platformTableContainer .platform-table-toolbar-actions {
@@ -264,22 +280,17 @@
   /* Button Container & Custom Buttons             */
   /* ============================================= */
   .button-container {
-    --button-gap: 12px;
-    --button-row-gap: 16px;
-    --button-min-width: clamp(110px, 24%, 260px);
-    --button-min-height: clamp(38px, 3.6vw, 70px);
-    --button-font-size: clamp(0.8rem, 0.75vw + 0.6rem, 1.25rem);
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    gap: var(--button-row-gap);
-    padding: 10px;
+    gap: var(--main-menu-button-row-gap);
+    padding: var(--main-menu-button-section-padding);
   }
 
   .button-container .button-row {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--button-gap);
+    gap: var(--main-menu-button-gap);
   }
 
   .custom-button {
@@ -288,12 +299,12 @@
     border: none;
     border-radius: 5px;
     cursor: pointer;
-    font-size: var(--button-font-size);
+    font-size: var(--main-menu-button-font-size);
     line-height: 1.2;
     padding: clamp(0.5rem, 0.35vw + 0.45rem, 0.8rem) clamp(0.85rem, 0.8vw + 0.65rem, 1.6rem);
     transition: background-color 0.3s ease, transform 0.2s ease;
-    flex: var(--button-col-span, 1) 1 var(--button-min-width);
-    min-height: var(--button-min-height);
+    flex: var(--button-col-span, 1) 1 var(--main-menu-button-min-width);
+    min-height: var(--main-menu-button-min-height);
     text-align: center;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     white-space: normal;
@@ -311,21 +322,21 @@
   }
 
   @media (max-width: 750px) {
-    .button-container {
-      --button-gap: 10px;
-      --button-row-gap: 14px;
-      --button-min-width: clamp(100px, 32vw, 220px);
-      --button-font-size: clamp(0.78rem, 1vw + 0.52rem, 1.15rem);
+    :root {
+      --main-menu-button-gap: 10px;
+      --main-menu-button-row-gap: 14px;
+      --main-menu-button-min-width: clamp(96px, 32vw, 220px);
+      --main-menu-button-font-size: clamp(0.76rem, 1vw + 0.5rem, 1.12rem);
     }
   }
 
   @media (max-width: 520px) {
-    .button-container {
-      --button-gap: 8px;
-      --button-row-gap: 12px;
-      --button-min-width: clamp(92px, 44vw, 200px);
-      --button-min-height: clamp(34px, 5.5vw, 60px);
-      --button-font-size: clamp(0.72rem, 1.1vw + 0.45rem, 1.05rem);
+    :root {
+      --main-menu-button-gap: 8px;
+      --main-menu-button-row-gap: 12px;
+      --main-menu-button-min-width: clamp(90px, 44vw, 200px);
+      --main-menu-button-min-height: clamp(32px, 5.3vw, 58px);
+      --main-menu-button-font-size: clamp(0.7rem, 1.05vw + 0.44rem, 1.02rem);
     }
   }
   

--- a/index.html
+++ b/index.html
@@ -139,6 +139,7 @@
   <script src="js/labels/label_storage.js"></script>
   <script src="js/export_laydown.js"></script>
   <script src="js/map_tools/map_tools_menu.js"></script>
+  <script src="js/config/main_menu_layout_config.js"></script>
   <script src="js/menu/main_menu_button_layout.js"></script>
   <script src="js/config/side_config.js"></script>
   <script src="js/config/map_settings.js"></script>

--- a/js/config/main_menu_layout_config.js
+++ b/js/config/main_menu_layout_config.js
@@ -1,0 +1,49 @@
+// js/config/main_menu_layout_config.js
+// Centralized configuration for main menu layout spacing and sizing.
+// Update the values in `window.MainMenuLayoutConfig` to quickly adjust the
+// presentation of the platform table and button container without editing CSS.
+// Example override (before this file loads):
+//   window.MainMenuLayoutConfig = { menuWidth: '28%', buttonGap: '12px' };
+
+(function(window, document) {
+  const defaults = {
+    menuWidth: '30%',
+    menuPadding: '16px',
+    menuContentGap: '12px',
+    menuHeaderGap: '6px',
+    menuToolbarGap: '8px',
+    buttonSectionPadding: '8px',
+    buttonRowGap: '12px',
+    buttonGap: '10px',
+    buttonMinWidth: 'clamp(100px, 22%, 240px)',
+    buttonMinHeight: 'clamp(34px, 3.1vw, 64px)',
+    buttonFontSize: 'clamp(0.78rem, 0.68vw + 0.55rem, 1.15rem)'
+  };
+
+  const settings = Object.assign({}, defaults, window.MainMenuLayoutConfig || {});
+
+  window.MainMenuLayoutConfig = settings;
+
+  const variableMap = {
+    menuWidth: '--main-menu-width',
+    menuPadding: '--main-menu-padding',
+    menuContentGap: '--main-menu-content-gap',
+    menuHeaderGap: '--main-menu-header-gap',
+    menuToolbarGap: '--main-menu-toolbar-gap',
+    buttonSectionPadding: '--main-menu-button-section-padding',
+    buttonRowGap: '--main-menu-button-row-gap',
+    buttonGap: '--main-menu-button-gap',
+    buttonMinWidth: '--main-menu-button-min-width',
+    buttonMinHeight: '--main-menu-button-min-height',
+    buttonFontSize: '--main-menu-button-font-size'
+  };
+
+  Object.keys(variableMap).forEach(function(key) {
+    const cssVariable = variableMap[key];
+    const value = settings[key];
+
+    if (typeof value === 'string' && value.trim().length > 0) {
+      document.documentElement.style.setProperty(cssVariable, value);
+    }
+  });
+})(window, document);


### PR DESCRIPTION
## Summary
- shrink the main menu platform table and tighten spacing using reusable CSS custom properties
- add a configurable script that exposes main menu layout settings via `window.MainMenuLayoutConfig`
- load the new layout configuration script so future updates can be made without touching CSS

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5078f6e6c832aa2134bd612c3846d