### PR TITLE
Adjust main menu layout spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,37 @@ structure. To supply a layout later (for example, after fetching scenario data),
 </script>
 ```
 
+### Adjusting menu spacing from a single configuration file
+
+The overall spacing between the platform table, its header, and the main menu button container is
+driven by CSS custom properties managed through `js/config/main_menu_layout.js`.
+
+Edit `window.MainMenuLayoutSettings` to change padding, flex sizing, and vertical limits without
+digging through stylesheets:
+
+```html
+<script>
+  window.MainMenuLayoutSettings = {
+    container: { padding: '16px', gap: '12px' },
+    table: { minHeight: '60vh' },
+    buttons: { maxHeight: '22vh', padding: '4px 12px' }
+  };
+</script>
+<script src="js/config/main_menu_layout.js"></script>
+<script src="js/menu/main_menu_layout_manager.js"></script>
+```
+
+The `MainMenuLayout` helper (exposed globally) also provides runtime methods for more advanced
+scenarios:
+
+```javascript
+MainMenuLayout.update({ buttons: { maxHeight: '30vh' } });
+console.log(MainMenuLayout.getSettings());
+```
+
+Any properties omitted from the configuration fall back to the defaults baked into
+`main_menu_layout_manager.js`.
+
 ## Configuring side definitions
 
 Global side metadata is defined in `js/config/side_config.js`. The file exposes a `SideConfig`

--- a/css/walt-menu-styles.css
+++ b/css/walt-menu-styles.css
@@ -12,6 +12,18 @@
 /* ============================================= */
 /* Platform Table Container                      */
 /* ============================================= */
+:root {
+    --main-menu-container-padding: 20px;
+    --main-menu-container-gap: 16px;
+    --main-menu-table-flex: 1 1 auto;
+    --main-menu-table-min-height: 52vh;
+    --main-menu-button-flex: 0 0 auto;
+    --main-menu-button-max-height: 28vh;
+    --main-menu-button-padding: 8px 12px;
+    --main-menu-button-gap: 10px;
+    --main-menu-button-row-gap: 12px;
+  }
+
 #platformTableContainer {
     --table-font-size: 13px;
     --table-header-font-size: 14px;
@@ -23,12 +35,12 @@
     float: right;
     display: flex;
     flex-direction: column;
-    padding: 20px;
+    padding: var(--main-menu-container-padding, 20px);
     box-sizing: border-box;
     border: 2px solid #ddd;
     background-color: #f9f9f9;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    gap: 16px;
+    gap: var(--main-menu-container-gap, 16px);
   }
 
 #platformTableContainer .platform-table-header {
@@ -105,10 +117,10 @@
 }
 
 #platformTableContainer .dataTables_wrapper {
-    flex: 1 1 auto;
+    flex: var(--main-menu-table-flex, 1 1 auto);
     display: flex;
     flex-direction: column;
-    min-height: 0;
+    min-height: var(--main-menu-table-min-height, 0);
 }
 
 #platformTableContainer .dataTables_filter,
@@ -264,8 +276,8 @@
   /* Button Container & Custom Buttons             */
   /* ============================================= */
   .button-container {
-    --button-gap: 12px;
-    --button-row-gap: 16px;
+    --button-gap: var(--main-menu-button-gap, 10px);
+    --button-row-gap: var(--main-menu-button-row-gap, 12px);
     --button-min-width: clamp(110px, 24%, 260px);
     --button-min-height: clamp(38px, 3.6vw, 70px);
     --button-font-size: clamp(0.8rem, 0.75vw + 0.6rem, 1.25rem);
@@ -273,7 +285,10 @@
     flex-direction: column;
     align-items: stretch;
     gap: var(--button-row-gap);
-    padding: 10px;
+    padding: var(--main-menu-button-padding, 8px 12px);
+    flex: var(--main-menu-button-flex, 0 0 auto);
+    max-height: var(--main-menu-button-max-height, none);
+    overflow-y: auto;
   }
 
   .button-container .button-row {

--- a/index.html
+++ b/index.html
@@ -139,6 +139,8 @@
   <script src="js/labels/label_storage.js"></script>
   <script src="js/export_laydown.js"></script>
   <script src="js/map_tools/map_tools_menu.js"></script>
+  <script src="js/config/main_menu_layout.js"></script>
+  <script src="js/menu/main_menu_layout_manager.js"></script>
   <script src="js/menu/main_menu_button_layout.js"></script>
   <script src="js/config/side_config.js"></script>
   <script src="js/config/map_settings.js"></script>

--- a/js/config/main_menu_layout.js
+++ b/js/config/main_menu_layout.js
@@ -1,0 +1,19 @@
+// js/config/main_menu_layout.js
+// Central configuration for the WALT main menu layout.
+
+window.MainMenuLayoutSettings = {
+  container: {
+    padding: '18px',
+    gap: '14px'
+  },
+  table: {
+    minHeight: '56vh'
+  },
+  buttons: {
+    maxHeight: '24vh',
+    padding: '6px 12px',
+    gap: '10px',
+    rowGap: '12px'
+  }
+};
+

--- a/js/menu/main_menu_layout_manager.js
+++ b/js/menu/main_menu_layout_manager.js
@@ -1,0 +1,115 @@
+// js/menu/main_menu_layout_manager.js
+// Applies configurable spacing and sizing options for the main menu layout.
+
+(function(global) {
+  const DEFAULTS = {
+    container: {
+      padding: '20px',
+      gap: '16px'
+    },
+    table: {
+      flex: '1 1 auto',
+      minHeight: '52vh'
+    },
+    buttons: {
+      flex: '0 0 auto',
+      maxHeight: '26vh',
+      padding: '8px 12px',
+      gap: '10px',
+      rowGap: '12px'
+    }
+  };
+
+  function isPlainObject(value) {
+    return Object.prototype.toString.call(value) === '[object Object]';
+  }
+
+  function deepMerge(target, source) {
+    const output = isPlainObject(target) ? { ...target } : {};
+
+    if (!isPlainObject(source)) {
+      return output;
+    }
+
+    Object.keys(source).forEach(function(key) {
+      const sourceValue = source[key];
+      const targetValue = output[key];
+
+      if (isPlainObject(sourceValue)) {
+        output[key] = deepMerge(isPlainObject(targetValue) ? targetValue : {}, sourceValue);
+      } else if (sourceValue !== undefined && sourceValue !== null) {
+        output[key] = String(sourceValue);
+      }
+    });
+
+    return output;
+  }
+
+  function buildSettings(overrides) {
+    return deepMerge(DEFAULTS, overrides);
+  }
+
+  function toVariableMap(settings) {
+    return {
+      '--main-menu-container-padding': settings.container.padding,
+      '--main-menu-container-gap': settings.container.gap,
+      '--main-menu-table-flex': settings.table.flex,
+      '--main-menu-table-min-height': settings.table.minHeight,
+      '--main-menu-button-flex': settings.buttons.flex,
+      '--main-menu-button-max-height': settings.buttons.maxHeight,
+      '--main-menu-button-padding': settings.buttons.padding,
+      '--main-menu-button-gap': settings.buttons.gap,
+      '--main-menu-button-row-gap': settings.buttons.rowGap
+    };
+  }
+
+  const overrides = isPlainObject(global.MainMenuLayoutSettings) ? global.MainMenuLayoutSettings : {};
+  let currentSettings = buildSettings(overrides);
+  global.MainMenuLayoutSettings = JSON.parse(JSON.stringify(currentSettings));
+
+  function applyVariables(settings) {
+    const root = document.documentElement;
+    const map = toVariableMap(settings);
+
+    Object.keys(map).forEach(function(variable) {
+      const value = map[variable];
+      if (typeof value === 'string') {
+        root.style.setProperty(variable, value);
+      }
+    });
+
+    global.MainMenuLayoutSettings = JSON.parse(JSON.stringify(settings));
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function() {
+      applyVariables(currentSettings);
+    });
+  } else {
+    applyVariables(currentSettings);
+  }
+
+  global.MainMenuLayout = {
+    apply: function(newSettings) {
+      if (newSettings && isPlainObject(newSettings)) {
+        currentSettings = buildSettings(newSettings);
+      }
+
+      applyVariables(currentSettings);
+      return this;
+    },
+    update: function(partialSettings) {
+      if (!isPlainObject(partialSettings)) {
+        return this;
+      }
+
+      currentSettings = deepMerge(currentSettings, partialSettings);
+      applyVariables(currentSettings);
+      return this;
+    },
+    getSettings: function() {
+      return JSON.parse(JSON.stringify(currentSettings));
+    }
+  };
+})(window);
+


### PR DESCRIPTION
## Summary
- increase the platform table footprint and tighten button container spacing with new CSS custom properties
- add a configurable main menu layout manager so spacing and sizing can be adjusted from a single settings file
- document how to use the new layout settings and keep index.html loading order in sync

## Testing
- python3 -m http.server 8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68e50983f9c8832a9f38a71ae69d1416