### PR TITLE
Refine main menu layout spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,39 @@ structure. To supply a layout later (for example, after fetching scenario data),
 </script>
 ```
 
+### Adjusting main menu spacing
+
+Spacing, padding, and sizing rules for the main menu live in
+`js/menu/main_menu_layout_config.js`. The module exposes a set of CSS custom properties on the menu
+container so that developers can quickly tweak the table-to-button ratio without editing the
+stylesheet. Define `window.MainMenuLayoutSettings` (or provide `layoutConfig` inside
+`window.MainMenuSettings`) before the script is loaded to override the defaults:
+
+```html
+<script>
+  window.MainMenuLayoutSettings = {
+    config: {
+      container: {
+        padding: '18px',
+        margin: '8px'
+      },
+      table: {
+        minHeight: '300px'
+      },
+      buttons: {
+        maxHeight: '24vh',
+        fontSize: 'clamp(0.72rem, 0.5vw + 0.55rem, 0.98rem)'
+      }
+    }
+  };
+</script>
+<script src="js/menu/main_menu_layout_config.js"></script>
+```
+
+Call `MainMenuLayout.apply(customConfig)` at runtime to adjust the spacing after the page has
+loaded. Only the properties you specify are changed, so it is easy to keep scenario-specific
+spacing overrides small.
+
 ## Configuring side definitions
 
 Global side metadata is defined in `js/config/side_config.js`. The file exposes a `SideConfig`

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,10 +1,24 @@
 /* styles.css */
 
-#map {
-   width: 65%;
+#waltAppLayout {
+   display: flex;
+   align-items: stretch;
+   justify-content: space-between;
+   width: 100%;
    height: 100vh;
-   float: left;
-   position: relative; 
+   box-sizing: border-box;
+   overflow: hidden;
+   flex-wrap: nowrap;
+}
+
+#map {
+   width: 60%;
+   max-width: 60%;
+   height: 100vh;
+   min-height: 100vh;
+   position: relative;
+   flex: 0 0 60%;
+   min-width: 0;
 }
 
 body {

--- a/css/walt-menu-styles.css
+++ b/css/walt-menu-styles.css
@@ -13,28 +13,36 @@
 /* Platform Table Container                      */
 /* ============================================= */
 #platformTableContainer {
+    --menu-padding: 24px;
+    --menu-margin: 12px;
+    --menu-gap: 20px;
+    --menu-header-gap: 10px;
+    --menu-toolbar-gap: 14px;
     --table-font-size: 13px;
     --table-header-font-size: 14px;
     --table-cell-padding: 10px;
     --table-line-height: 1.4;
+    --table-min-height: 340px;
+    --table-flex: 1 1 auto;
     overflow: hidden;
     width: 35%;
-    height: 100vh;
+    height: calc(100vh - (2 * var(--menu-margin, 0px)));
     float: right;
     display: flex;
     flex-direction: column;
-    padding: 20px;
+    padding: var(--menu-padding);
+    margin: var(--menu-margin);
     box-sizing: border-box;
     border: 2px solid #ddd;
     background-color: #f9f9f9;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    gap: 16px;
+    gap: var(--menu-gap);
   }
 
 #platformTableContainer .platform-table-header {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: var(--menu-header-gap, 8px);
     flex: 0 0 auto;
 }
 
@@ -42,7 +50,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: 12px;
+    gap: var(--menu-toolbar-gap, 12px);
 }
 
 #platformTableContainer .platform-table-toolbar-actions {
@@ -105,10 +113,10 @@
 }
 
 #platformTableContainer .dataTables_wrapper {
-    flex: 1 1 auto;
+    flex: var(--table-flex, 1 1 auto);
     display: flex;
     flex-direction: column;
-    min-height: 0;
+    min-height: var(--table-min-height, 0);
 }
 
 #platformTableContainer .dataTables_filter,
@@ -264,16 +272,23 @@
   /* Button Container & Custom Buttons             */
   /* ============================================= */
   .button-container {
-    --button-gap: 12px;
-    --button-row-gap: 16px;
-    --button-min-width: clamp(110px, 24%, 260px);
-    --button-min-height: clamp(38px, 3.6vw, 70px);
-    --button-font-size: clamp(0.8rem, 0.75vw + 0.6rem, 1.25rem);
+    --button-gap: 10px;
+    --button-row-gap: 14px;
+    --button-min-width: clamp(120px, 22%, 240px);
+    --button-min-height: clamp(36px, 2.8vw, 58px);
+    --button-font-size: clamp(0.78rem, 0.55vw + 0.6rem, 1.05rem);
+    --button-padding-block: clamp(0.45rem, 0.28vw + 0.35rem, 0.65rem);
+    --button-padding-inline: clamp(0.75rem, 0.65vw + 0.5rem, 1.35rem);
+    --button-container-padding: 12px;
+    --button-container-max-height: 28vh;
     display: flex;
     flex-direction: column;
     align-items: stretch;
     gap: var(--button-row-gap);
-    padding: 10px;
+    padding: var(--button-container-padding);
+    max-height: var(--button-container-max-height);
+    overflow-y: auto;
+    flex: 0 0 auto;
   }
 
   .button-container .button-row {
@@ -290,7 +305,7 @@
     cursor: pointer;
     font-size: var(--button-font-size);
     line-height: 1.2;
-    padding: clamp(0.5rem, 0.35vw + 0.45rem, 0.8rem) clamp(0.85rem, 0.8vw + 0.65rem, 1.6rem);
+    padding: var(--button-padding-block) var(--button-padding-inline);
     transition: background-color 0.3s ease, transform 0.2s ease;
     flex: var(--button-col-span, 1) 1 var(--button-min-width);
     min-height: var(--button-min-height);
@@ -312,20 +327,22 @@
 
   @media (max-width: 750px) {
     .button-container {
-      --button-gap: 10px;
-      --button-row-gap: 14px;
-      --button-min-width: clamp(100px, 32vw, 220px);
-      --button-font-size: clamp(0.78rem, 1vw + 0.52rem, 1.15rem);
+      --button-gap: 8px;
+      --button-row-gap: 12px;
+      --button-min-width: clamp(110px, 30vw, 220px);
+      --button-font-size: clamp(0.76rem, 0.85vw + 0.5rem, 1.05rem);
+      --button-container-max-height: 32vh;
     }
   }
 
   @media (max-width: 520px) {
     .button-container {
-      --button-gap: 8px;
-      --button-row-gap: 12px;
+      --button-gap: 6px;
+      --button-row-gap: 10px;
       --button-min-width: clamp(92px, 44vw, 200px);
-      --button-min-height: clamp(34px, 5.5vw, 60px);
-      --button-font-size: clamp(0.72rem, 1.1vw + 0.45rem, 1.05rem);
+      --button-min-height: clamp(32px, 5vw, 54px);
+      --button-font-size: clamp(0.7rem, 1vw + 0.45rem, 0.98rem);
+      --button-container-max-height: 36vh;
     }
   }
   

--- a/css/walt-menu-styles.css
+++ b/css/walt-menu-styles.css
@@ -18,6 +18,7 @@
     --menu-gap: 20px;
     --menu-header-gap: 10px;
     --menu-toolbar-gap: 14px;
+    --menu-column-width: calc(40% - (2 * var(--menu-margin, 0px)));
     --table-font-size: 13px;
     --table-header-font-size: 14px;
     --table-cell-padding: 10px;
@@ -25,10 +26,12 @@
     --table-min-height: 340px;
     --table-flex: 1 1 auto;
     overflow: hidden;
-    width: 35%;
+    width: var(--menu-column-width);
+    max-width: var(--menu-column-width);
     height: calc(100vh - (2 * var(--menu-margin, 0px)));
-    float: right;
+    max-height: calc(100vh - (2 * var(--menu-margin, 0px)));
     display: flex;
+    flex: 0 0 var(--menu-column-width);
     flex-direction: column;
     padding: var(--menu-padding);
     margin: var(--menu-margin);

--- a/index.html
+++ b/index.html
@@ -139,6 +139,7 @@
   <script src="js/labels/label_storage.js"></script>
   <script src="js/export_laydown.js"></script>
   <script src="js/map_tools/map_tools_menu.js"></script>
+  <script src="js/menu/main_menu_layout_config.js"></script>
   <script src="js/menu/main_menu_button_layout.js"></script>
   <script src="js/config/side_config.js"></script>
   <script src="js/config/map_settings.js"></script>

--- a/index.html
+++ b/index.html
@@ -45,51 +45,53 @@
   <!------------------------------------->
   <!------------ Map Objects ------------>
   <!------------------------------------->
-  <!-- Map Container -->
-  <div id="map">
-    <!-- Clear Markers Button (clears selection of markers from the map) -->
-    <button id="clearSelectedButton">
-      Clear Markers
-    </button>
-    <!-- Clear Range Rings Button -->
-    <button id="clearRangeRingsButton">
-      Clear Range Rings
-    </button>
-  </div>
+  <div id="waltAppLayout">
+    <!-- Map Container -->
+    <div id="map">
+      <!-- Clear Markers Button (clears selection of markers from the map) -->
+      <button id="clearSelectedButton">
+        Clear Markers
+      </button>
+      <!-- Clear Range Rings Button -->
+      <button id="clearRangeRingsButton">
+        Clear Range Rings
+      </button>
+    </div>
 
-  <!------------------------------------------->
-  <!------------ WALT Menu Objects ------------>
-  <!------------------------------------------->
-  <!-- Platform Table and Controls Container -->
-  <div id="platformTableContainer">
-    <div class="platform-table-header">
-      <h2 class="platform-table-title">Warfighting Analysis Laydown Tool (WALT)</h2>
-      <div class="platform-table-toolbar">
-        <h3 class="platform-table-subtitle">Platforms</h3>
-        <div class="platform-table-toolbar-actions">
-          <button
-            type="button"
-            id="columnToggleButton"
-            class="column-toggle-button"
-            aria-haspopup="true"
-            aria-expanded="false"
-            aria-controls="columnToggleMenu"
-          >
-            Columns
-          </button>
-          <div
-            id="columnToggleMenu"
-            class="column-toggle-menu"
-            role="menu"
-            aria-hidden="true"
-          ></div>
+    <!------------------------------------------->
+    <!------------ WALT Menu Objects ------------>
+    <!------------------------------------------->
+    <!-- Platform Table and Controls Container -->
+    <div id="platformTableContainer">
+      <div class="platform-table-header">
+        <h2 class="platform-table-title">Warfighting Analysis Laydown Tool (WALT)</h2>
+        <div class="platform-table-toolbar">
+          <h3 class="platform-table-subtitle">Platforms</h3>
+          <div class="platform-table-toolbar-actions">
+            <button
+              type="button"
+              id="columnToggleButton"
+              class="column-toggle-button"
+              aria-haspopup="true"
+              aria-expanded="false"
+              aria-controls="columnToggleMenu"
+            >
+              Columns
+            </button>
+            <div
+              id="columnToggleMenu"
+              class="column-toggle-menu"
+              role="menu"
+              aria-hidden="true"
+            ></div>
+          </div>
         </div>
       </div>
+      <!-- Data Table -->
+      <table id="platformTable" class="display"></table>
+      <!-- Button Controls -->
+      <div class="button-container" id="mainMenuButtonContainer"></div>
     </div>
-    <!-- Data Table -->
-    <table id="platformTable" class="display"></table>
-    <!-- Button Controls -->
-    <div class="button-container" id="mainMenuButtonContainer"></div>
   </div>
 
   <!-------------------------------------------------------->

--- a/js/menu/main_menu_layout_config.js
+++ b/js/menu/main_menu_layout_config.js
@@ -1,0 +1,140 @@
+// js/menu/main_menu_layout_config.js
+// Applies configurable spacing and sizing rules to the main menu container so layouts can
+// be tuned from a single place (or overridden by scenarios).
+
+(function(global) {
+  var DEFAULT_CONTAINER_SELECTOR = '#platformTableContainer';
+
+  var DEFAULT_CONFIG = {
+    container: {
+      padding: '24px',
+      margin: '12px',
+      gap: '20px'
+    },
+    header: {
+      gap: '10px'
+    },
+    toolbar: {
+      gap: '14px'
+    },
+    table: {
+      minHeight: '340px',
+      flex: '1 1 auto'
+    },
+    buttons: {
+      padding: '12px',
+      maxHeight: '28vh',
+      gap: '10px',
+      rowGap: '14px',
+      minWidth: 'clamp(120px, 22%, 240px)',
+      minHeight: 'clamp(36px, 2.8vw, 58px)',
+      fontSize: 'clamp(0.78rem, 0.55vw + 0.6rem, 1.05rem)',
+      paddingBlock: 'clamp(0.45rem, 0.28vw + 0.35rem, 0.65rem)',
+      paddingInline: 'clamp(0.75rem, 0.65vw + 0.5rem, 1.35rem)'
+    }
+  };
+
+  var PROPERTY_MAP = {
+    container: {
+      padding: '--menu-padding',
+      margin: '--menu-margin',
+      gap: '--menu-gap'
+    },
+    header: {
+      gap: '--menu-header-gap'
+    },
+    toolbar: {
+      gap: '--menu-toolbar-gap'
+    },
+    table: {
+      minHeight: '--table-min-height',
+      flex: '--table-flex'
+    },
+    buttons: {
+      padding: '--button-container-padding',
+      maxHeight: '--button-container-max-height',
+      gap: '--button-gap',
+      rowGap: '--button-row-gap',
+      minWidth: '--button-min-width',
+      minHeight: '--button-min-height',
+      fontSize: '--button-font-size',
+      paddingBlock: '--button-padding-block',
+      paddingInline: '--button-padding-inline'
+    }
+  };
+
+  function isPlainObject(value) {
+    return value && typeof value === 'object' && !Array.isArray(value);
+  }
+
+  function deepMerge(target, source) {
+    var output = {};
+    var keys = Object.keys(target || {});
+    keys.forEach(function(key) {
+      if (isPlainObject(target[key])) {
+        output[key] = deepMerge(target[key], (source || {})[key]);
+      } else {
+        output[key] = target[key];
+      }
+    });
+
+    Object.keys(source || {}).forEach(function(key) {
+      if (!isPlainObject(source[key])) {
+        output[key] = source[key];
+        return;
+      }
+
+      output[key] = deepMerge(target && target[key], source[key]);
+    });
+
+    return output;
+  }
+
+  function applyConfig(config, containerSelector) {
+    var selector = containerSelector || DEFAULT_CONTAINER_SELECTOR;
+    var container = document.querySelector(selector);
+
+    if (!container) {
+      return;
+    }
+
+    Object.keys(PROPERTY_MAP).forEach(function(section) {
+      var sectionConfig = (config || {})[section] || {};
+      var propertyMap = PROPERTY_MAP[section];
+
+      Object.keys(propertyMap).forEach(function(key) {
+        var cssVariable = propertyMap[key];
+        var value = sectionConfig[key];
+
+        if (typeof value === 'string' && value.trim() !== '') {
+          container.style.setProperty(cssVariable, value);
+        }
+      });
+    });
+  }
+
+  var layoutSettings = global.MainMenuLayoutSettings || {};
+  var menuSettings = global.MainMenuSettings || {};
+
+  var configOverrides = layoutSettings.config || menuSettings.layoutConfig;
+  var containerSelector = layoutSettings.containerSelector || menuSettings.layoutContainerSelector;
+  var autoApply = layoutSettings.autoApply !== false;
+  var baseConfig = deepMerge(DEFAULT_CONFIG, configOverrides || {});
+
+  if (autoApply) {
+    applyConfig(baseConfig, containerSelector);
+  }
+
+  global.MainMenuLayout = {
+    apply: function(customConfig, customSelector) {
+      var resolved = deepMerge(baseConfig, customConfig || {});
+      applyConfig(resolved, customSelector || containerSelector);
+    },
+    getDefaultConfig: function() {
+      return deepMerge(DEFAULT_CONFIG, {});
+    },
+    getBaseConfig: function() {
+      return deepMerge(baseConfig, {});
+    }
+  };
+})(window);


### PR DESCRIPTION
## Summary
- increase the platform table footprint while tightening button sizing in the main menu
- expose menu spacing and sizing controls via a reusable layout configuration script
- document how to override the menu spacing defaults for scenario-specific layouts

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68e52af45770832a80e8ad96db40ab27