### PR TITLE
Add weapon lethality management dialog and export

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -67,3 +67,88 @@ body {
     line-height: 1.3;
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
 }
+
+/* Weapon lethality configuration dialog */
+.weapon-lethality-config {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.weapon-lethality-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+}
+
+.weapon-lethality-table thead th {
+    text-align: left;
+    padding: 8px;
+    border-bottom: 2px solid #d1d5db;
+    background-color: #f3f4f6;
+}
+
+.weapon-lethality-table tbody td {
+    padding: 8px;
+    border-bottom: 1px solid #e5e7eb;
+    vertical-align: middle;
+}
+
+.weapon-lethality-select,
+.weapon-lethality-quantity {
+    width: 100%;
+    padding: 6px;
+    border: 1px solid #cbd5f5;
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
+.weapon-lethality-actions {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.weapon-lethality-actions button {
+    padding: 8px 16px;
+    border-radius: 4px;
+    border: 1px solid #cbd5f5;
+    background-color: #f9fafb;
+    cursor: pointer;
+}
+
+.weapon-lethality-actions button.primary {
+    background-color: #2563eb;
+    color: #fff;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.weapon-lethality-actions button.primary:hover {
+    background-color: #1d4ed8;
+}
+
+.weapon-lethality-actions button:hover,
+.weapon-lethality-table .delete-lethality-row:hover {
+    background-color: #e5e7eb;
+}
+
+.weapon-lethality-table .delete-lethality-row {
+    padding: 6px 12px;
+    border: 1px solid #f87171;
+    background-color: #fee2e2;
+    color: #b91c1c;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.weapon-lethality-table .delete-lethality-row:hover {
+    background-color: #fecaca;
+}
+
+.weapon-lethality-empty {
+    font-size: 14px;
+    line-height: 1.5;
+}

--- a/dialog_init.js
+++ b/dialog_init.js
@@ -65,7 +65,23 @@ $(function () {
       draggable: true,
       resizable: true,
       width: 400,
-      position: { 
+      position: {
+        my: "center",
+        at: "center+0+150",
+        of: window
+      }
+    });
+  });
+
+  $(function () {
+    // Initialize Weapon Lethality Dialog
+    $("#weaponLethalityDialog").dialog({
+      modal: true,
+      autoOpen: false,
+      draggable: true,
+      resizable: true,
+      width: 720,
+      position: {
         my: "center",
         at: "center+0+150",
         of: window

--- a/export_laydown.html
+++ b/export_laydown.html
@@ -81,6 +81,7 @@
     <div class="button-grid">
       <button id="copy-platforms">Copy platforms to clipboard</button>
       <button id="copy-weapons">Copy weapons to clipboard</button>
+      <button id="copy-weapon-lethality">Copy weapon lethality to clipboard</button>
       <button id="copy-sensors">Copy sensors to clipboard</button>
       <button id="copy-labels">Copy labels to clipboard</button>
     </div>
@@ -90,6 +91,7 @@
       const buttonConfigs = [
         { id: 'copy-platforms', storageKey: 'platformLaydownData' },
         { id: 'copy-weapons', storageKey: 'weaponLaydownData' },
+        { id: 'copy-weapon-lethality', storageKey: 'weaponLethalityLaydownData' },
         { id: 'copy-sensors', storageKey: 'sensorLaydownData' },
         { id: 'copy-labels', storageKey: 'labelLaydownData' }
       ];

--- a/index.html
+++ b/index.html
@@ -127,6 +127,7 @@
   <!--------------------------------------->
   <script src="input/platform_details.js"></script>
   <script src="input/weapon_details.js"></script>
+  <script src="input/weapon_lethality_details.js"></script>
   <script src="input/sensor_details.js"></script>
   <script src="input/labels.js"></script>
 
@@ -136,6 +137,7 @@
   <!-- Storage Scripts -->
   <script src="js/platforms/platform_model.js"></script>
   <script src="js/weapons/weapon_storage.js"></script>
+  <script src="js/weapons/weapon_lethality_storage.js"></script>
   <script src="js/sensors/sensor_storage.js"></script>
   <script src="js/distance_storage.js"></script>
   <script src="js/labels/label_storage.js"></script>
@@ -167,6 +169,7 @@
   <script src="js/platforms/plat_config.js"></script>
   <script src="js/platforms/create_plat_config.js"></script>
   <script src="js/weapons/weapon_config.js"></script>
+  <script src="js/weapons/weapon_lethality_config.js"></script>
   <script src="js/sensors/sensor_config.js"></script>
 
 
@@ -196,6 +199,11 @@
   <!-- Range Ring Info Dialog -->
   <div id="rangeRingInfoDialog" title="Range Ring Configuration">
     <p id="rangeRingInfoContent"></p>
+  </div>
+
+  <!-- Weapon Lethality Dialog -->
+  <div id="weaponLethalityDialog" title="Weapon Lethality">
+    <p id="weaponLethalityContent"></p>
   </div>
 
   <!-- Create Platform Dialog -->

--- a/init.js
+++ b/init.js
@@ -19,6 +19,7 @@ document.addEventListener('contextmenu', function(event) { // Disable right clic
 PlatformModel.loadInitialData(PLATFORM_DATA); // Store platform data from platform_details.js
 DistanceStorage.initializeDistanceData(); // Catalogue the distances between every platform in the scenario using PlatformModel
 WeaponStorage.loadInitialData(WEAPON_DATA); // Store weapon data from weapon_details.js
+WeaponLethalityStorage.loadInitialData(WEAPON_LETHALITY_DATA); // Store lethality data from weapon_lethality_details.js
 SensorStorage.loadInitialData(SENSOR_DATA); // Store sensor data from sensor_details.js
 LabelStorage.loadInitialData(LABEL_DATA); // Store label data from labels.js
 RangeRingStorage.init(); // Use platform data and weapon range data to catalogue all of the range rings that exist

--- a/input/weapon_lethality_details.js
+++ b/input/weapon_lethality_details.js
@@ -1,0 +1,10 @@
+var WEAPON_LETHALITY_DATA = [
+  { "weapon": "BLUE_WEAPON_1", "platform": "blue_ship_1", "quantity": 12 },
+  { "weapon": "BLUE_WEAPON_2", "platform": "blue_ship_2", "quantity": 8 },
+  { "weapon": "BLUE_WEAPON_3", "platform": "blue_ship_3", "quantity": 6 },
+  { "weapon": "BLUE_WEAPON_4", "platform": "blue_ship_4", "quantity": 10 },
+  { "weapon": "RED_WEAPON_1", "platform": "red_ship_1", "quantity": 14 },
+  { "weapon": "RED_WEAPON_2", "platform": "red_ship_2", "quantity": 9 },
+  { "weapon": "RED_WEAPON_3", "platform": "red_ship_3", "quantity": 5 },
+  { "weapon": "RED_WEAPON_4", "platform": "red_ship_4", "quantity": 11 }
+];

--- a/js/export_laydown.js
+++ b/js/export_laydown.js
@@ -7,11 +7,13 @@ var LaydownExporter = (function() {
     function exportLaydown() {
         var platformDataStr = PlatformModel.exportData();
         var weaponDataStr = WeaponStorage.exportData();
+        var weaponLethalityDataStr = WeaponLethalityStorage.exportData();
         var sensorDataStr = SensorStorage.exportData();
         var labelDataStr = JSON.stringify(LabelStorage.getLabelData(), null, 2);
 
         sessionStorage.setItem('platformLaydownData', formatData('PLATFORM_DATA', platformDataStr));
         sessionStorage.setItem('weaponLaydownData', formatData('WEAPON_DATA', weaponDataStr));
+        sessionStorage.setItem('weaponLethalityLaydownData', formatData('WEAPON_LETHALITY_DATA', weaponLethalityDataStr));
         sessionStorage.setItem('sensorLaydownData', formatData('SENSOR_DATA', sensorDataStr));
         sessionStorage.setItem('labelLaydownData', formatData('LABEL_DATA', labelDataStr));
 

--- a/js/menu/main_menu_button_layout.js
+++ b/js/menu/main_menu_button_layout.js
@@ -15,6 +15,7 @@ var MainMenuButtons = (function(global) {
     [
       { id: 'rangeRingsButton', label: 'Range Rings' },
       { id: 'weaponsButton', label: 'Weapons' },
+      { id: 'weaponLethalityButton', label: 'Weapon Lethality' },
       { id: 'sensorsButton', label: 'Sensors' }
     ],
     [

--- a/js/view.js
+++ b/js/view.js
@@ -126,6 +126,11 @@ var View = (function() {
             WeaponConfig.createWeaponConfigDialog();
         });
 
+        // Add Weapon Lethality Configuration button functionality
+        document.getElementById('weaponLethalityButton').addEventListener('click', function() {
+            WeaponLethalityConfig.createWeaponLethalityConfigDialog();
+        });
+
         // Add Sensor Configuration button functionality
         document.getElementById('sensorsButton').addEventListener('click', function() {
             SensorConfig.createSensorConfigDialog();

--- a/js/weapons/weapon_lethality_config.js
+++ b/js/weapons/weapon_lethality_config.js
@@ -1,0 +1,176 @@
+// js/weapons/weapon_lethality_config.js
+var WeaponLethalityConfig = (function() {
+    function escapeHtml(value) {
+        return String(value || '').replace(/["&'<>]/g, function(char) {
+            switch (char) {
+                case '"': return '&quot;';
+                case "'": return '&#39;';
+                case '&': return '&amp;';
+                case '<': return '&lt;';
+                case '>': return '&gt;';
+                default: return char;
+            }
+        });
+    }
+
+    function buildOptions(options, selectedValue) {
+        return options.map(function(option) {
+            var value = option.value || option;
+            var label = option.label || option;
+            var isSelected = value === selectedValue;
+            return '<option value="' + escapeHtml(value) + '"' + (isSelected ? ' selected' : '') + '>' + escapeHtml(label) + '</option>';
+        }).join('');
+    }
+
+    function createRowHtml(rowData, weapons, platforms) {
+        var weaponOptions = buildOptions(weapons, rowData.weapon);
+        var platformOptions = buildOptions(platforms, rowData.platform);
+        var quantity = typeof rowData.quantity === 'number' ? rowData.quantity : 0;
+
+        return [
+            '<tr>',
+            '  <td><select class="weapon-lethality-select weapon-select">' + weaponOptions + '</select></td>',
+            '  <td><select class="weapon-lethality-select platform-select">' + platformOptions + '</select></td>',
+            '  <td class="quantity-cell">',
+            '    <input type="number" class="weapon-lethality-quantity" min="0" step="1" value="' + escapeHtml(quantity) + '">',
+            '  </td>',
+            '  <td class="actions-cell">',
+            '    <button type="button" class="delete-lethality-row">Delete</button>',
+            '  </td>',
+            '</tr>'
+        ].join('');
+    }
+
+    function renderTableRows(lethalityData, weapons, platforms) {
+        if (!Array.isArray(lethalityData) || lethalityData.length === 0) {
+            return createRowHtml({
+                weapon: weapons.length > 0 ? weapons[0].value || weapons[0] : '',
+                platform: platforms.length > 0 ? platforms[0].value || platforms[0] : '',
+                quantity: 0
+            }, weapons, platforms);
+        }
+
+        return lethalityData.map(function(entry) {
+            return createRowHtml(entry, weapons, platforms);
+        }).join('');
+    }
+
+    function getWeaponOptions() {
+        var weaponData = WeaponStorage.getWeaponData() || [];
+        return weaponData.map(function(weapon) {
+            return weapon.weapon_name;
+        });
+    }
+
+    function getPlatformOptions() {
+        var platformNames = PlatformModel.getPlatformNames() || [];
+        return platformNames;
+    }
+
+    function collectTableData(dialogRoot) {
+        var rows = [];
+        dialogRoot.find('#weaponLethalityTable tbody tr').each(function() {
+            var row = $(this);
+            var weapon = row.find('.weapon-select').val();
+            var platform = row.find('.platform-select').val();
+            var quantityValue = row.find('.weapon-lethality-quantity').val();
+            var quantity = parseInt(quantityValue, 10);
+
+            rows.push({
+                weapon: weapon || '',
+                platform: platform || '',
+                quantity: isNaN(quantity) ? 0 : Math.max(quantity, 0)
+            });
+        });
+        return rows;
+    }
+
+    function handleSave(dialogRoot) {
+        var tableData = collectTableData(dialogRoot);
+        var hasInvalid = tableData.some(function(entry) {
+            return !entry.weapon || !entry.platform || typeof entry.quantity !== 'number' || entry.quantity < 0;
+        });
+
+        if (hasInvalid) {
+            alert('Each row must include a weapon, a platform, and a non-negative quantity.');
+            return;
+        }
+
+        WeaponLethalityStorage.setLethalityData(tableData);
+        alert('Weapon lethality data has been updated successfully.');
+    }
+
+    function handleAddRow(dialogRoot, weapons, platforms) {
+        if (weapons.length === 0 || platforms.length === 0) {
+            return;
+        }
+        var newRowHtml = createRowHtml({
+            weapon: weapons[0].value || weapons[0],
+            platform: platforms[0].value || platforms[0],
+            quantity: 0
+        }, weapons, platforms);
+        dialogRoot.find('#weaponLethalityTable tbody').append(newRowHtml);
+    }
+
+    function bindEvents(dialogRoot, weapons, platforms) {
+        dialogRoot.off('click', '#addWeaponLethalityRow').on('click', '#addWeaponLethalityRow', function() {
+            handleAddRow(dialogRoot, weapons, platforms);
+        });
+
+        dialogRoot.off('click', '#saveWeaponLethality').on('click', '#saveWeaponLethality', function() {
+            handleSave(dialogRoot);
+        });
+
+        dialogRoot.off('click', '.delete-lethality-row').on('click', '.delete-lethality-row', function() {
+            $(this).closest('tr').remove();
+        });
+    }
+
+    function createWeaponLethalityConfigDialog() {
+        var weapons = getWeaponOptions();
+        var platforms = getPlatformOptions();
+
+        if (weapons.length === 0 || platforms.length === 0) {
+            var message = '<p class="weapon-lethality-empty">Weapon and platform data are required before configuring weapon lethality. Please ensure both datasets are loaded.</p>';
+            $('#weaponLethalityDialog').html(message).dialog('open');
+            return;
+        }
+
+        weapons = weapons.map(function(name) { return { value: name, label: name }; });
+        platforms = platforms.map(function(name) { return { value: name, label: name }; });
+
+        var lethalityData = WeaponLethalityStorage.getLethalityData() || [];
+        var rowsHtml = renderTableRows(lethalityData, weapons, platforms);
+
+        var layout = [
+            '<div class="weapon-lethality-config">',
+            '  <table id="weaponLethalityTable" class="weapon-lethality-table">',
+            '    <thead>',
+            '      <tr>',
+            '        <th>Weapon</th>',
+            '        <th>Platform</th>',
+            '        <th>Quantity</th>',
+            '        <th></th>',
+            '      </tr>',
+            '    </thead>',
+            '    <tbody>',
+            rowsHtml,
+            '    </tbody>',
+            '  </table>',
+            '  <div class="weapon-lethality-actions">',
+            '    <button type="button" id="addWeaponLethalityRow">Add Row</button>',
+            '    <button type="button" id="saveWeaponLethality" class="primary">Save</button>',
+            '  </div>',
+            '</div>'
+        ].join('');
+
+        var dialogRoot = $('#weaponLethalityDialog');
+        dialogRoot.html(layout);
+        bindEvents(dialogRoot, weapons, platforms);
+        dialogRoot.dialog('open');
+    }
+
+    return {
+        createWeaponLethalityConfigDialog: createWeaponLethalityConfigDialog
+    };
+})();

--- a/js/weapons/weapon_lethality_storage.js
+++ b/js/weapons/weapon_lethality_storage.js
@@ -1,0 +1,46 @@
+// js/weapons/weapon_lethality_storage.js
+var WeaponLethalityStorage = (function() {
+    var lethalityData = [];
+
+    function normalizeEntry(entry) {
+        if (!entry || typeof entry !== 'object') {
+            return { weapon: '', platform: '', quantity: 0 };
+        }
+
+        var quantity = parseInt(entry.quantity, 10);
+        return {
+            weapon: entry.weapon || '',
+            platform: entry.platform || '',
+            quantity: isNaN(quantity) ? 0 : quantity
+        };
+    }
+
+    function loadInitialData(initialData) {
+        lethalityData = Array.isArray(initialData) ? initialData.map(normalizeEntry) : [];
+    }
+
+    function getLethalityData() {
+        return lethalityData;
+    }
+
+    function setLethalityData(newData) {
+        lethalityData = Array.isArray(newData) ? newData.map(normalizeEntry) : [];
+    }
+
+    function exportData() {
+        return JSON.stringify(lethalityData, null, 2);
+    }
+
+    var originalObject = {
+        loadInitialData: loadInitialData,
+        getLethalityData: getLethalityData,
+        setLethalityData: setLethalityData,
+        exportData: exportData
+    };
+
+    return new Proxy(originalObject, {
+        get: function(target, prop) {
+            return target[prop];
+        }
+    });
+})();


### PR DESCRIPTION
## Summary
- add a weapon lethality dataset, storage module, and menu button wired into the main configuration dialogs
- load and edit lethality pairings via a configurable table that supports adding/removing rows while updating storage
- extend the export laydown workflow with clipboard support for the lethality dataset and supporting styles

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e53883b934832a9c36cbc2be85fdad