### PR TITLE
Add weapon lethality management dialog and export

### DIFF
--- a/dialog_init.js
+++ b/dialog_init.js
@@ -31,6 +31,22 @@ $(function () {
   });
 
   $(function () {
+    // Initialize Weapon Lethality Dialog
+    $("#weaponLethalityDialog").dialog({
+      modal: true,
+      autoOpen: false,
+      draggable: true,
+      resizable: true,
+      width: 700,
+      position: {
+        my: "center",
+        at: "center+0+150",
+        of: window
+      }
+    });
+  });
+
+  $(function () {
     // Initialize Sensor Info Dialog
     $("#sensorInfoDialog").dialog({
       modal: true,

--- a/export_laydown.html
+++ b/export_laydown.html
@@ -81,6 +81,7 @@
     <div class="button-grid">
       <button id="copy-platforms">Copy platforms to clipboard</button>
       <button id="copy-weapons">Copy weapons to clipboard</button>
+      <button id="copy-weapon-lethality">Copy weapon lethality to clipboard</button>
       <button id="copy-sensors">Copy sensors to clipboard</button>
       <button id="copy-labels">Copy labels to clipboard</button>
     </div>
@@ -90,6 +91,7 @@
       const buttonConfigs = [
         { id: 'copy-platforms', storageKey: 'platformLaydownData' },
         { id: 'copy-weapons', storageKey: 'weaponLaydownData' },
+        { id: 'copy-weapon-lethality', storageKey: 'weaponLethalityLaydownData' },
         { id: 'copy-sensors', storageKey: 'sensorLaydownData' },
         { id: 'copy-labels', storageKey: 'labelLaydownData' }
       ];

--- a/index.html
+++ b/index.html
@@ -127,6 +127,7 @@
   <!--------------------------------------->
   <script src="input/platform_details.js"></script>
   <script src="input/weapon_details.js"></script>
+  <script src="input/weapon_lethality_details.js"></script>
   <script src="input/sensor_details.js"></script>
   <script src="input/labels.js"></script>
 
@@ -136,6 +137,7 @@
   <!-- Storage Scripts -->
   <script src="js/platforms/platform_model.js"></script>
   <script src="js/weapons/weapon_storage.js"></script>
+  <script src="js/weapon_lethality/weapon_lethality_storage.js"></script>
   <script src="js/sensors/sensor_storage.js"></script>
   <script src="js/distance_storage.js"></script>
   <script src="js/labels/label_storage.js"></script>
@@ -167,6 +169,7 @@
   <script src="js/platforms/plat_config.js"></script>
   <script src="js/platforms/create_plat_config.js"></script>
   <script src="js/weapons/weapon_config.js"></script>
+  <script src="js/weapon_lethality/weapon_lethality_config.js"></script>
   <script src="js/sensors/sensor_config.js"></script>
 
 
@@ -186,6 +189,11 @@
   <!-- Weapon Info Dialog -->
   <div id="weaponInfoDialog" title="Weapon Configuration">
     <p id="weaponInfoContent"></p>
+  </div>
+
+  <!-- Weapon Lethality Dialog -->
+  <div id="weaponLethalityDialog" title="Weapon Lethality">
+    <div id="weaponLethalityContent"></div>
   </div>
 
   <!-- Sensor Info Dialog -->

--- a/init.js
+++ b/init.js
@@ -19,6 +19,7 @@ document.addEventListener('contextmenu', function(event) { // Disable right clic
 PlatformModel.loadInitialData(PLATFORM_DATA); // Store platform data from platform_details.js
 DistanceStorage.initializeDistanceData(); // Catalogue the distances between every platform in the scenario using PlatformModel
 WeaponStorage.loadInitialData(WEAPON_DATA); // Store weapon data from weapon_details.js
+WeaponLethalityStorage.loadInitialData(WEAPON_LETHALITY_DATA); // Store weapon lethality data from weapon_lethality_details.js
 SensorStorage.loadInitialData(SENSOR_DATA); // Store sensor data from sensor_details.js
 LabelStorage.loadInitialData(LABEL_DATA); // Store label data from labels.js
 RangeRingStorage.init(); // Use platform data and weapon range data to catalogue all of the range rings that exist

--- a/input/weapon_lethality_details.js
+++ b/input/weapon_lethality_details.js
@@ -1,0 +1,42 @@
+var WEAPON_LETHALITY_DATA = [
+  {
+    "weapon": "BLUE_WEAPON_1",
+    "platform": "blue_ship_1",
+    "quantity": 12
+  },
+  {
+    "weapon": "BLUE_WEAPON_2",
+    "platform": "blue_ship_3",
+    "quantity": 6
+  },
+  {
+    "weapon": "BLUE_WEAPON_4",
+    "platform": "blue_ship_2",
+    "quantity": 4
+  },
+  {
+    "weapon": "RED_WEAPON_1",
+    "platform": "red_ship_1",
+    "quantity": 3
+  },
+  {
+    "weapon": "RED_WEAPON_3",
+    "platform": "red_ship_4",
+    "quantity": 10
+  },
+  {
+    "weapon": "RED_WEAPON_5",
+    "platform": "red_ship_2",
+    "quantity": 8
+  },
+  {
+    "weapon": "RED_WEAPON_7",
+    "platform": "red_ship_5",
+    "quantity": 5
+  },
+  {
+    "weapon": "RED_WEAPON_8",
+    "platform": "red_ship_3",
+    "quantity": 9
+  }
+];

--- a/js/export_laydown.js
+++ b/js/export_laydown.js
@@ -7,11 +7,13 @@ var LaydownExporter = (function() {
     function exportLaydown() {
         var platformDataStr = PlatformModel.exportData();
         var weaponDataStr = WeaponStorage.exportData();
+        var weaponLethalityDataStr = WeaponLethalityStorage.exportData();
         var sensorDataStr = SensorStorage.exportData();
         var labelDataStr = JSON.stringify(LabelStorage.getLabelData(), null, 2);
 
         sessionStorage.setItem('platformLaydownData', formatData('PLATFORM_DATA', platformDataStr));
         sessionStorage.setItem('weaponLaydownData', formatData('WEAPON_DATA', weaponDataStr));
+        sessionStorage.setItem('weaponLethalityLaydownData', formatData('WEAPON_LETHALITY_DATA', weaponLethalityDataStr));
         sessionStorage.setItem('sensorLaydownData', formatData('SENSOR_DATA', sensorDataStr));
         sessionStorage.setItem('labelLaydownData', formatData('LABEL_DATA', labelDataStr));
 

--- a/js/menu/main_menu_button_layout.js
+++ b/js/menu/main_menu_button_layout.js
@@ -15,7 +15,8 @@ var MainMenuButtons = (function(global) {
     [
       { id: 'rangeRingsButton', label: 'Range Rings' },
       { id: 'weaponsButton', label: 'Weapons' },
-      { id: 'sensorsButton', label: 'Sensors' }
+      { id: 'sensorsButton', label: 'Sensors' },
+      { id: 'weaponLethalityButton', label: 'Weapon Lethality' }
     ],
     [
       { id: 'openChartsButton', label: 'Display Results' },

--- a/js/view.js
+++ b/js/view.js
@@ -126,6 +126,10 @@ var View = (function() {
             WeaponConfig.createWeaponConfigDialog();
         });
 
+        document.getElementById('weaponLethalityButton').addEventListener('click', function() {
+            WeaponLethalityConfig.createWeaponLethalityDialog();
+        });
+
         // Add Sensor Configuration button functionality
         document.getElementById('sensorsButton').addEventListener('click', function() {
             SensorConfig.createSensorConfigDialog();

--- a/js/weapon_lethality/weapon_lethality_config.js
+++ b/js/weapon_lethality/weapon_lethality_config.js
@@ -1,0 +1,162 @@
+// js/weapon_lethality/weapon_lethality_config.js
+var WeaponLethalityConfig = (function() {
+    var TABLE_SELECTOR = '#weaponLethalityTable';
+
+    function getWeapons() {
+        if (typeof WeaponStorage !== 'undefined' && typeof WeaponStorage.getWeaponData === 'function') {
+            return WeaponStorage.getWeaponData();
+        }
+        return [];
+    }
+
+    function getPlatforms() {
+        if (typeof PlatformModel !== 'undefined' && typeof PlatformModel.getPlatformData === 'function') {
+            return PlatformModel.getPlatformData();
+        }
+        return [];
+    }
+
+    function buildWeaponOptions(selectedWeapon) {
+        var weapons = getWeapons();
+        if (!weapons.length && selectedWeapon) {
+            weapons = [{ weapon_name: selectedWeapon }];
+        }
+        return weapons.map(function(weapon) {
+            var value = weapon.weapon_name || '';
+            var isSelected = value === selectedWeapon;
+            return '<option value="' + value + '"' + (isSelected ? ' selected' : '') + '>' + value + '</option>';
+        }).join('');
+    }
+
+    function buildPlatformOptions(selectedPlatform) {
+        var platforms = getPlatforms();
+        if (!platforms.length && selectedPlatform) {
+            platforms = [{ platform_name: selectedPlatform }];
+        }
+        return platforms.map(function(platform) {
+            var value = platform.platform_name || '';
+            var isSelected = value === selectedPlatform;
+            return '<option value="' + value + '"' + (isSelected ? ' selected' : '') + '>' + value + '</option>';
+        }).join('');
+    }
+
+    function buildRow(entry, index) {
+        return [
+            '<select class="weapon-lethality-weapon" data-row-index="' + index + '">' + buildWeaponOptions(entry.weapon) + '</select>',
+            '<select class="weapon-lethality-platform" data-row-index="' + index + '">' + buildPlatformOptions(entry.platform) + '</select>',
+            '<div class="weapon-lethality-quantity-cell" style="display: flex; align-items: center; gap: 8px;">' +
+                '<input type="number" min="0" step="1" class="weapon-lethality-quantity" data-row-index="' + index + '" value="' + entry.quantity + '">' +
+                '<button type="button" class="weapon-lethality-delete" data-row-index="' + index + '">Delete</button>' +
+            '</div>'
+        ];
+    }
+
+    function renderTableBody() {
+        var lethalityData = WeaponLethalityStorage.getLethalityData();
+        var tbody = document.querySelector(TABLE_SELECTOR + ' tbody');
+        if (!tbody) {
+            return;
+        }
+        var rowsHtml = lethalityData.map(function(entry, index) {
+            var rowPieces = buildRow(entry, index);
+            return '<tr data-row-index="' + index + '">' +
+                '<td>' + rowPieces[0] + '</td>' +
+                '<td>' + rowPieces[1] + '</td>' +
+                '<td>' + rowPieces[2] + '</td>' +
+                '</tr>';
+        }).join('');
+
+        tbody.innerHTML = rowsHtml;
+    }
+
+    function initDataTable() {
+        $(TABLE_SELECTOR).DataTable({
+            paging: false,
+            searching: false,
+            info: false,
+            ordering: false,
+            autoWidth: false,
+            columnDefs: [
+                { targets: [2], orderable: false }
+            ]
+        });
+    }
+
+    function refreshTable() {
+        if ($.fn.DataTable.isDataTable(TABLE_SELECTOR)) {
+            $(TABLE_SELECTOR).DataTable().destroy();
+        }
+        renderTableBody();
+        initDataTable();
+        bindRowEvents();
+    }
+
+    function bindRowEvents() {
+        var table = $(TABLE_SELECTOR);
+        table.off('change', '.weapon-lethality-weapon').on('change', '.weapon-lethality-weapon', function() {
+            var index = parseInt($(this).data('row-index'), 10);
+            WeaponLethalityStorage.updateEntry(index, { weapon: $(this).val() });
+        });
+
+        table.off('change', '.weapon-lethality-platform').on('change', '.weapon-lethality-platform', function() {
+            var index = parseInt($(this).data('row-index'), 10);
+            WeaponLethalityStorage.updateEntry(index, { platform: $(this).val() });
+        });
+
+        table.off('input', '.weapon-lethality-quantity').on('input', '.weapon-lethality-quantity', function() {
+            var index = parseInt($(this).data('row-index'), 10);
+            WeaponLethalityStorage.updateEntry(index, { quantity: $(this).val() });
+        });
+
+        table.off('click', '.weapon-lethality-delete').on('click', '.weapon-lethality-delete', function() {
+            var index = parseInt($(this).data('row-index'), 10);
+            WeaponLethalityStorage.removeEntry(index);
+            refreshTable();
+        });
+    }
+
+    function createWeaponLethalityDialog() {
+        var dialogContent = '' +
+            '<table id="weaponLethalityTable" class="display">' +
+            '<thead>' +
+            '<tr>' +
+            '<th>Weapon</th>' +
+            '<th>Platform</th>' +
+            '<th>Quantity</th>' +
+            '</tr>' +
+            '</thead>' +
+            '<tbody></tbody>' +
+            '</table>' +
+            '<div class="weapon-lethality-toolbar" style="margin-top: 10px; display: flex; justify-content: flex-start; gap: 8px;">' +
+            '<button id="addWeaponLethalityRow" type="button">Add Pairing</button>' +
+            '</div>';
+
+        $('#weaponLethalityContent').html(dialogContent);
+        refreshTable();
+
+        $('#weaponLethalityDialog').dialog('open');
+
+        $('#addWeaponLethalityRow').off('click').on('click', function() {
+            var weapons = getWeapons();
+            var platforms = getPlatforms();
+
+            if (!weapons.length || !platforms.length) {
+                alert('At least one weapon and one platform are required before creating lethality pairings.');
+                return;
+            }
+
+            WeaponLethalityStorage.addEntry({
+                weapon: weapons[0].weapon_name || '',
+                platform: platforms[0].platform_name || '',
+                quantity: 1
+            });
+
+            refreshTable();
+        });
+    }
+
+    return {
+        createWeaponLethalityDialog: createWeaponLethalityDialog,
+        refreshTable: refreshTable
+    };
+})();

--- a/js/weapon_lethality/weapon_lethality_storage.js
+++ b/js/weapon_lethality/weapon_lethality_storage.js
@@ -1,0 +1,103 @@
+// js/weapon_lethality/weapon_lethality_storage.js
+var WeaponLethalityStorage = (function() {
+    var lethalityData = [];
+    var nextId = 1;
+
+    function cloneEntry(entry) {
+        return {
+            id: entry.id || null,
+            weapon: entry.weapon || '',
+            platform: entry.platform || '',
+            quantity: typeof entry.quantity === 'number' ? entry.quantity : parseInt(entry.quantity, 10) || 0
+        };
+    }
+
+    function generateId() {
+        return 'wl-' + (nextId++);
+    }
+
+    function loadInitialData(initialData) {
+        nextId = 1;
+        lethalityData = Array.isArray(initialData) ? initialData.map(function(item) {
+            var cloned = cloneEntry(item);
+            if (cloned.id && typeof cloned.id === 'string') {
+                return cloned;
+            }
+            cloned.id = generateId();
+            return cloned;
+        }) : [];
+        // Ensure the nextId counter stays ahead of any provided IDs that include an incrementing suffix
+        lethalityData.forEach(function(entry) {
+            var match = /wl-(\d+)/.exec(entry.id);
+            if (match) {
+                var numeric = parseInt(match[1], 10);
+                if (!isNaN(numeric) && numeric >= nextId) {
+                    nextId = numeric + 1;
+                }
+            }
+        });
+    }
+
+    function getLethalityData() {
+        return lethalityData;
+    }
+
+    function addEntry(entry) {
+        var newEntry = cloneEntry(entry || {});
+        if (!newEntry.id) {
+            newEntry.id = generateId();
+        }
+        lethalityData.push(newEntry);
+        return newEntry;
+    }
+
+    function updateEntry(index, updates) {
+        if (!lethalityData[index]) {
+            return;
+        }
+        var entry = lethalityData[index];
+        if (updates.weapon !== undefined) {
+            entry.weapon = updates.weapon;
+        }
+        if (updates.platform !== undefined) {
+            entry.platform = updates.platform;
+        }
+        if (updates.quantity !== undefined) {
+            var parsed = parseInt(updates.quantity, 10);
+            entry.quantity = isNaN(parsed) ? 0 : parsed;
+        }
+    }
+
+    function removeEntry(index) {
+        if (index >= 0 && index < lethalityData.length) {
+            lethalityData.splice(index, 1);
+        }
+    }
+
+    function setLethalityData(newData) {
+        if (Array.isArray(newData)) {
+            loadInitialData(newData);
+        }
+    }
+
+    function exportData() {
+        var exportable = lethalityData.map(function(entry) {
+            return {
+                weapon: entry.weapon,
+                platform: entry.platform,
+                quantity: entry.quantity
+            };
+        });
+        return JSON.stringify(exportable, null, 2);
+    }
+
+    return {
+        loadInitialData: loadInitialData,
+        getLethalityData: getLethalityData,
+        addEntry: addEntry,
+        updateEntry: updateEntry,
+        removeEntry: removeEntry,
+        setLethalityData: setLethalityData,
+        exportData: exportData
+    };
+})();


### PR DESCRIPTION
## Summary
- add a Weapon Lethality main menu entry with a dialog for editing weapon-platform quantities using DataTables
- load the lethality table from a new weapon_lethality_details.js seed file and persist updates through WeaponLethalityStorage
- include the lethality dataset in the laydown export workflow with a dedicated copy-to-clipboard button

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e53d6826f8832a894aeb875dc582f6