### PR TITLE
Add weapon lethality management system

### DIFF
--- a/dialog_init.js
+++ b/dialog_init.js
@@ -22,7 +22,23 @@ $(function () {
       draggable: true,
       resizable: true,
       width: 700,
-      position: { 
+      position: {
+        my: "center",
+        at: "center+0+150",
+        of: window
+      }
+    });
+  });
+
+  $(function () {
+    // Initialize Weapon Lethality Dialog
+    $("#weaponLethalityDialog").dialog({
+      modal: true,
+      autoOpen: false,
+      draggable: true,
+      resizable: true,
+      width: 800,
+      position: {
         my: "center",
         at: "center+0+150",
         of: window

--- a/export_laydown.html
+++ b/export_laydown.html
@@ -83,6 +83,7 @@
       <button id="copy-weapons">Copy weapons to clipboard</button>
       <button id="copy-sensors">Copy sensors to clipboard</button>
       <button id="copy-labels">Copy labels to clipboard</button>
+      <button id="copy-weapon-lethality">Copy weapon lethality to clipboard</button>
     </div>
   </main>
   <script>
@@ -91,7 +92,8 @@
         { id: 'copy-platforms', storageKey: 'platformLaydownData' },
         { id: 'copy-weapons', storageKey: 'weaponLaydownData' },
         { id: 'copy-sensors', storageKey: 'sensorLaydownData' },
-        { id: 'copy-labels', storageKey: 'labelLaydownData' }
+        { id: 'copy-labels', storageKey: 'labelLaydownData' },
+        { id: 'copy-weapon-lethality', storageKey: 'weaponLethalityLaydownData' }
       ];
 
       function copyData(button, storageKey) {

--- a/index.html
+++ b/index.html
@@ -127,6 +127,7 @@
   <!--------------------------------------->
   <script src="input/platform_details.js"></script>
   <script src="input/weapon_details.js"></script>
+  <script src="input/weapon_lethality_details.js"></script>
   <script src="input/sensor_details.js"></script>
   <script src="input/labels.js"></script>
 
@@ -136,6 +137,7 @@
   <!-- Storage Scripts -->
   <script src="js/platforms/platform_model.js"></script>
   <script src="js/weapons/weapon_storage.js"></script>
+  <script src="js/weapon_lethality/weapon_lethality_storage.js"></script>
   <script src="js/sensors/sensor_storage.js"></script>
   <script src="js/distance_storage.js"></script>
   <script src="js/labels/label_storage.js"></script>
@@ -167,6 +169,7 @@
   <script src="js/platforms/plat_config.js"></script>
   <script src="js/platforms/create_plat_config.js"></script>
   <script src="js/weapons/weapon_config.js"></script>
+  <script src="js/weapon_lethality/weapon_lethality_config.js"></script>
   <script src="js/sensors/sensor_config.js"></script>
 
 
@@ -186,6 +189,11 @@
   <!-- Weapon Info Dialog -->
   <div id="weaponInfoDialog" title="Weapon Configuration">
     <p id="weaponInfoContent"></p>
+  </div>
+
+  <!-- Weapon Lethality Dialog -->
+  <div id="weaponLethalityDialog" title="Weapon Lethality Configuration">
+    <p id="weaponLethalityContent"></p>
   </div>
 
   <!-- Sensor Info Dialog -->

--- a/init.js
+++ b/init.js
@@ -19,6 +19,7 @@ document.addEventListener('contextmenu', function(event) { // Disable right clic
 PlatformModel.loadInitialData(PLATFORM_DATA); // Store platform data from platform_details.js
 DistanceStorage.initializeDistanceData(); // Catalogue the distances between every platform in the scenario using PlatformModel
 WeaponStorage.loadInitialData(WEAPON_DATA); // Store weapon data from weapon_details.js
+WeaponLethalityStorage.loadInitialData(WEAPON_LETHALITY_DATA); // Store weapon lethality data from weapon_lethality_details.js
 SensorStorage.loadInitialData(SENSOR_DATA); // Store sensor data from sensor_details.js
 LabelStorage.loadInitialData(LABEL_DATA); // Store label data from labels.js
 RangeRingStorage.init(); // Use platform data and weapon range data to catalogue all of the range rings that exist

--- a/input/weapon_lethality_details.js
+++ b/input/weapon_lethality_details.js
@@ -1,0 +1,22 @@
+var WEAPON_LETHALITY_DATA = [
+  { "weapon": "BLUE_WEAPON_1", "platform": "blue_ship_1", "quantity": 12 },
+  { "weapon": "BLUE_WEAPON_2", "platform": "blue_ship_1", "quantity": 8 },
+  { "weapon": "BLUE_WEAPON_3", "platform": "blue_ship_2", "quantity": 6 },
+  { "weapon": "BLUE_WEAPON_4", "platform": "blue_ship_2", "quantity": 10 },
+  { "weapon": "BLUE_WEAPON_5", "platform": "blue_ship_3", "quantity": 4 },
+  { "weapon": "BLUE_WEAPON_1", "platform": "blue_ship_4", "quantity": 14 },
+  { "weapon": "BLUE_WEAPON_2", "platform": "blue_ship_5", "quantity": 7 },
+  { "weapon": "BLUE_WEAPON_3", "platform": "blue_ship_6", "quantity": 5 },
+  { "weapon": "BLUE_WEAPON_4", "platform": "blue_ship_7", "quantity": 9 },
+  { "weapon": "BLUE_WEAPON_5", "platform": "blue_ship_8", "quantity": 3 },
+  { "weapon": "RED_WEAPON_1", "platform": "red_ship_1", "quantity": 11 },
+  { "weapon": "RED_WEAPON_2", "platform": "red_ship_1", "quantity": 6 },
+  { "weapon": "RED_WEAPON_3", "platform": "red_ship_2", "quantity": 8 },
+  { "weapon": "RED_WEAPON_4", "platform": "red_ship_2", "quantity": 13 },
+  { "weapon": "RED_WEAPON_5", "platform": "red_ship_3", "quantity": 5 },
+  { "weapon": "RED_WEAPON_6", "platform": "red_ship_4", "quantity": 9 },
+  { "weapon": "RED_WEAPON_7", "platform": "red_ship_5", "quantity": 4 },
+  { "weapon": "RED_WEAPON_8", "platform": "red_ship_6", "quantity": 7 },
+  { "weapon": "RED_WEAPON_3", "platform": "red_ship_7", "quantity": 12 },
+  { "weapon": "RED_WEAPON_4", "platform": "red_ship_8", "quantity": 10 }
+];

--- a/js/export_laydown.js
+++ b/js/export_laydown.js
@@ -8,11 +8,13 @@ var LaydownExporter = (function() {
         var platformDataStr = PlatformModel.exportData();
         var weaponDataStr = WeaponStorage.exportData();
         var sensorDataStr = SensorStorage.exportData();
+        var weaponLethalityDataStr = WeaponLethalityStorage.exportData();
         var labelDataStr = JSON.stringify(LabelStorage.getLabelData(), null, 2);
 
         sessionStorage.setItem('platformLaydownData', formatData('PLATFORM_DATA', platformDataStr));
         sessionStorage.setItem('weaponLaydownData', formatData('WEAPON_DATA', weaponDataStr));
         sessionStorage.setItem('sensorLaydownData', formatData('SENSOR_DATA', sensorDataStr));
+        sessionStorage.setItem('weaponLethalityLaydownData', formatData('WEAPON_LETHALITY_DATA', weaponLethalityDataStr));
         sessionStorage.setItem('labelLaydownData', formatData('LABEL_DATA', labelDataStr));
 
         window.open('export_laydown.html', '_blank');

--- a/js/menu/main_menu_button_layout.js
+++ b/js/menu/main_menu_button_layout.js
@@ -15,6 +15,7 @@ var MainMenuButtons = (function(global) {
     [
       { id: 'rangeRingsButton', label: 'Range Rings' },
       { id: 'weaponsButton', label: 'Weapons' },
+      { id: 'weaponLethalityButton', label: 'Weapon Lethality' },
       { id: 'sensorsButton', label: 'Sensors' }
     ],
     [

--- a/js/view.js
+++ b/js/view.js
@@ -126,6 +126,11 @@ var View = (function() {
             WeaponConfig.createWeaponConfigDialog();
         });
 
+        // Add Weapon Lethality Configuration button functionality
+        document.getElementById('weaponLethalityButton').addEventListener('click', function() {
+            WeaponLethalityConfig.createWeaponLethalityDialog();
+        });
+
         // Add Sensor Configuration button functionality
         document.getElementById('sensorsButton').addEventListener('click', function() {
             SensorConfig.createSensorConfigDialog();

--- a/js/weapon_lethality/weapon_lethality_config.js
+++ b/js/weapon_lethality/weapon_lethality_config.js
@@ -1,0 +1,263 @@
+// js/weapon_lethality/weapon_lethality_config.js
+var WeaponLethalityConfig = (function($) {
+    var tableInstance = null;
+
+    function getWeaponOptions() {
+        var weapons = [];
+        if (typeof WeaponStorage !== 'undefined' && typeof WeaponStorage.getWeaponData === 'function') {
+            weapons = WeaponStorage.getWeaponData().map(function(weapon) {
+                return weapon.weapon_name;
+            });
+        }
+        return weapons.filter(Boolean).sort(function(a, b) {
+            return a.localeCompare(b);
+        });
+    }
+
+    function getPlatformOptions() {
+        var platforms = [];
+        if (typeof PlatformModel !== 'undefined' && typeof PlatformModel.getPlatformData === 'function') {
+            platforms = PlatformModel.getPlatformData().map(function(platform) {
+                return platform.platform_name;
+            });
+        }
+        return platforms.filter(Boolean).sort(function(a, b) {
+            return a.localeCompare(b);
+        });
+    }
+
+    function escapeHtml(value) {
+        if (typeof value !== 'string') {
+            return '';
+        }
+
+        var entityMap = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;'
+        };
+
+        return value.replace(/[&<>"']/g, function(character) {
+            return entityMap[character] || character;
+        });
+    }
+
+    function buildOptions(options, selectedValue) {
+        if (!options.length) {
+            if (selectedValue) {
+                var safeSelectedOnly = escapeHtml(selectedValue);
+                return '<option value="' + safeSelectedOnly + '" selected>' + safeSelectedOnly + '</option>';
+            }
+            return '<option value="">Not Available</option>';
+        }
+
+        var optionsMap = {};
+
+        var optionsHtml = options.map(function(option) {
+            var selected = option === selectedValue ? ' selected' : '';
+            optionsMap[option] = true;
+            var safeOption = escapeHtml(option);
+            return '<option value="' + safeOption + '"' + selected + '>' + safeOption + '</option>';
+        }).join('');
+
+        if (selectedValue && !optionsMap[selectedValue]) {
+            var safeSelected = escapeHtml(selectedValue);
+            optionsHtml += '<option value="' + safeSelected + '" selected>' + safeSelected + '</option>';
+        }
+
+        return optionsHtml;
+    }
+
+    function createWeaponSelect(selectedValue) {
+        var options = buildOptions(getWeaponOptions(), selectedValue);
+        return '<select class="lethality-weapon">' + options + '</select>';
+    }
+
+    function createPlatformSelect(selectedValue) {
+        var options = buildOptions(getPlatformOptions(), selectedValue);
+        return '<select class="lethality-platform">' + options + '</select>';
+    }
+
+    function createQuantityInput(value) {
+        var safeValue = typeof value === 'number' ? value : parseInt(value, 10) || 0;
+        return '<input type="number" class="lethality-quantity" min="0" value="' + safeValue + '">';
+    }
+
+    function createDeleteButton() {
+        return '<button type="button" class="delete-lethality">Delete</button>';
+    }
+
+    function destroyExistingTable() {
+        if (tableInstance) {
+            tableInstance.destroy();
+            tableInstance = null;
+        }
+    }
+
+    function renderTableBody(data) {
+        var rowsHtml = data.map(function(entry) {
+            return '<tr>' +
+                '<td>' + createWeaponSelect(entry.weapon) + '</td>' +
+                '<td>' + createPlatformSelect(entry.platform) + '</td>' +
+                '<td>' + createQuantityInput(entry.quantity) + '</td>' +
+                '<td>' + createDeleteButton() + '</td>' +
+            '</tr>';
+        }).join('');
+
+        return rowsHtml;
+    }
+
+    function buildDialogContent(pairings) {
+        var content = '';
+        content += '<table id="weaponLethalityTable" class="display" style="width: 100%">';
+        content += '<thead><tr>' +
+            '<th>Weapon</th>' +
+            '<th>Platform</th>' +
+            '<th>Quantity</th>' +
+            '<th>Actions</th>' +
+            '</tr></thead>';
+        content += '<tbody>' + renderTableBody(pairings) + '</tbody>';
+        content += '</table>';
+        content += '<div class="weapon-lethality-actions" style="margin-top: 10px; display: flex; justify-content: space-between;">';
+        content += '<button type="button" id="addLethalityPairing">Add Pairing</button>';
+        content += '<button type="button" id="saveWeaponLethality">Save Changes</button>';
+        content += '</div>';
+        return content;
+    }
+
+    function initialiseDataTable() {
+        var hasWeaponOptions = getWeaponOptions().length > 0;
+        var hasPlatformOptions = getPlatformOptions().length > 0;
+
+        tableInstance = $('#weaponLethalityTable').DataTable({
+            paging: true,
+            searching: true,
+            info: true,
+            ordering: false,
+            autoWidth: false,
+            lengthChange: false,
+            pageLength: 10,
+            language: {
+                emptyTable: hasWeaponOptions && hasPlatformOptions ? 'No weapon lethality pairings available.' : 'Weapon and platform data are required to configure lethality pairings.'
+            }
+        });
+    }
+
+    function addPairingRow() {
+        if (!tableInstance) {
+            return;
+        }
+
+        var weaponOptions = getWeaponOptions();
+        var platformOptions = getPlatformOptions();
+
+        if (!weaponOptions.length || !platformOptions.length) {
+            alert('Weapons and platforms must be available to create lethality pairings.');
+            return;
+        }
+
+        var defaultWeapon = weaponOptions[0];
+        var defaultPlatform = platformOptions[0];
+
+        tableInstance.row.add([
+            createWeaponSelect(defaultWeapon),
+            createPlatformSelect(defaultPlatform),
+            createQuantityInput(0),
+            createDeleteButton()
+        ]).draw(false);
+    }
+
+    function bindEvents() {
+        $('#addLethalityPairing').off('click').on('click', function() {
+            addPairingRow();
+        });
+
+        $('#saveWeaponLethality').off('click').on('click', function() {
+            saveChanges();
+        });
+
+        $('#weaponLethalityTable').off('click', '.delete-lethality').on('click', '.delete-lethality', function() {
+            if (!tableInstance) {
+                return;
+            }
+            tableInstance.row($(this).closest('tr')).remove().draw(false);
+        });
+    }
+
+    function gatherTableData() {
+        if (!tableInstance) {
+            return [];
+        }
+
+        var nodes = tableInstance.rows().nodes();
+        var updatedData = [];
+        var hasError = false;
+
+        $(nodes).each(function() {
+            if (hasError) {
+                return;
+            }
+
+            var weapon = $(this).find('.lethality-weapon').val();
+            var platform = $(this).find('.lethality-platform').val();
+            var quantityValue = $(this).find('.lethality-quantity').val();
+            var quantity = parseInt(quantityValue, 10);
+
+            if (!weapon || !platform) {
+                alert('Each pairing must have both a weapon and a platform selected.');
+                hasError = true;
+                return;
+            }
+
+            if (isNaN(quantity) || quantity < 0) {
+                alert('Quantities must be zero or greater.');
+                hasError = true;
+                return;
+            }
+
+            updatedData.push({
+                weapon: weapon,
+                platform: platform,
+                quantity: quantity
+            });
+        });
+
+        if (hasError) {
+            return null;
+        }
+
+        return updatedData;
+    }
+
+    function saveChanges() {
+        var updatedData = gatherTableData();
+        if (!updatedData) {
+            return;
+        }
+
+        WeaponLethalityStorage.setWeaponLethalityData(updatedData);
+        alert('Weapon lethality data updated successfully.');
+    }
+
+    function createWeaponLethalityDialog() {
+        if (typeof WeaponLethalityStorage === 'undefined') {
+            console.warn('WeaponLethalityStorage is not available.');
+            return;
+        }
+
+        var pairings = WeaponLethalityStorage.getWeaponLethalityData();
+        destroyExistingTable();
+
+        $('#weaponLethalityContent').html(buildDialogContent(pairings));
+        $('#weaponLethalityDialog').dialog('open');
+
+        initialiseDataTable();
+        bindEvents();
+    }
+
+    return {
+        createWeaponLethalityDialog: createWeaponLethalityDialog
+    };
+})(jQuery);

--- a/js/weapon_lethality/weapon_lethality_storage.js
+++ b/js/weapon_lethality/weapon_lethality_storage.js
@@ -1,0 +1,67 @@
+// js/weapon_lethality/weapon_lethality_storage.js
+var WeaponLethalityStorage = (function() {
+    var lethalityData = [];
+
+    function cloneEntry(entry) {
+        return {
+            weapon: entry && entry.weapon ? entry.weapon : '',
+            platform: entry && entry.platform ? entry.platform : '',
+            quantity: typeof entry.quantity === 'number' ? entry.quantity : parseInt(entry.quantity, 10) || 0
+        };
+    }
+
+    function loadInitialData(initialData) {
+        if (!Array.isArray(initialData)) {
+            lethalityData = [];
+            return;
+        }
+
+        lethalityData = initialData.map(function(entry) {
+            return cloneEntry(entry);
+        });
+    }
+
+    function getWeaponLethalityData() {
+        return lethalityData;
+    }
+
+    function setWeaponLethalityData(newData) {
+        if (!Array.isArray(newData)) {
+            return;
+        }
+
+        lethalityData = newData.map(function(entry) {
+            return cloneEntry(entry);
+        });
+    }
+
+    function addPairing(pairing) {
+        lethalityData.push(cloneEntry(pairing));
+    }
+
+    function removePairing(index) {
+        if (index >= 0 && index < lethalityData.length) {
+            lethalityData.splice(index, 1);
+        }
+    }
+
+    function updatePairing(index, updates) {
+        if (index >= 0 && index < lethalityData.length) {
+            lethalityData[index] = Object.assign({}, lethalityData[index], cloneEntry(updates));
+        }
+    }
+
+    function exportData() {
+        return JSON.stringify(lethalityData, null, 2);
+    }
+
+    return {
+        loadInitialData: loadInitialData,
+        getWeaponLethalityData: getWeaponLethalityData,
+        setWeaponLethalityData: setWeaponLethalityData,
+        addPairing: addPairing,
+        removePairing: removePairing,
+        updatePairing: updatePairing,
+        exportData: exportData
+    };
+})();


### PR DESCRIPTION
## Summary
- add storage, configuration UI, and input data for weapon lethality pairings
- wire the new weapon lethality editor into the main menu and initialize it with scenario assets
- enable exporting the weapon lethality table from the laydown exporter page

## Testing
- Manual testing: python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e6569290e0832aa8aa363520d30d8f