### PR TITLE
Simplify missions placeholder styling

### DIFF
--- a/js/menu/main_menu_button_layout.js
+++ b/js/menu/main_menu_button_layout.js
@@ -23,6 +23,9 @@ var MainMenuButtons = (function(global) {
       { id: 'refreshDataButton', label: 'Refresh Data' }
     ],
     [
+      { id: 'missionsButton', label: 'Missions' }
+    ],
+    [
       { id: 'exportLaydownButton', label: 'Export Laydown' }
     ]
   ];

--- a/js/view.js
+++ b/js/view.js
@@ -157,6 +157,11 @@ var View = (function() {
         // Add an event listener to the 'Display Results' button
         document.getElementById('refreshDataButton').addEventListener('click', updateAll);
 
+        // Navigate to the Missions page when requested
+        document.getElementById('missionsButton').addEventListener('click', function () {
+            window.location.href = 'missions.html';
+        });
+
     }
 
     // Render platforms from platform details

--- a/missions.html
+++ b/missions.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WALT Missions</title>
+
+  <!-- External Libraries -->
+  <link rel="stylesheet" href="libs/jquery/jquery-ui.css">
+
+  <!-- Custom Stylesheets -->
+  <link rel="stylesheet" href="missions/css/missions.css">
+</head>
+<body>
+  <header class="missions-header">
+    <h1>Missions</h1>
+    <p class="missions-subtitle">This page is ready for mission planning features.</p>
+  </header>
+
+  <main id="missions-root" class="missions-content" aria-live="polite">
+    <section class="missions-placeholder">
+      <h2>Placeholder</h2>
+      <p>Use <code>missions/js/missions.js</code> for behavior and <code>missions/css/missions.css</code> for styling.</p>
+    </section>
+  </main>
+
+  <!-- External Scripts -->
+  <script src="libs/jquery/jquery.min.js"></script>
+  <script src="libs/jquery/jquery-ui.js"></script>
+
+  <!-- Page Scripts -->
+  <script src="missions/js/missions.js"></script>
+</body>
+</html>

--- a/missions/css/missions.css
+++ b/missions/css/missions.css
@@ -1,0 +1,49 @@
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  background-color: #ffffff;
+  color: #1f2933;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.missions-header {
+  padding: 1.5rem 1rem;
+  border-bottom: 1px solid #d9e1f1;
+}
+
+.missions-header h1 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.missions-subtitle {
+  margin: 0.5rem 0 0;
+  color: #4c596c;
+  font-size: 1rem;
+}
+
+.missions-content {
+  flex: 1;
+  padding: 2rem 1rem;
+}
+
+.missions-placeholder {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 1.5rem;
+  border: 1px dashed #c8d2e4;
+  border-radius: 6px;
+  background-color: #ffffff;
+}
+
+.missions-placeholder h2 {
+  margin-top: 0;
+  font-size: 1.25rem;
+}
+
+.missions-placeholder p {
+  margin-bottom: 0;
+  line-height: 1.5;
+}

--- a/missions/js/missions.js
+++ b/missions/js/missions.js
@@ -1,0 +1,13 @@
+(function () {
+  'use strict';
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const root = document.getElementById('missions-root');
+    if (!root) {
+      return;
+    }
+
+    // Placeholder hook for future mission planning modules.
+    root.dataset.ready = 'true';
+  });
+})();


### PR DESCRIPTION
## Summary
- simplify the missions placeholder markup to reference where functionality and styling belong
- replace the previous themed missions stylesheet with a light, minimal layout for easier future customization

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e671292e40832a8358e1790a22e4e3