### PR TITLE
Implement mission generation module and UI

### DIFF
--- a/js/distance_storage.js
+++ b/js/distance_storage.js
@@ -1,7 +1,7 @@
 // distance_storage.js
 
 // Uses the custom GroundRange module from GroundRange.js to calculate the distance
-// between two points. 
+// between two points.
 
 var DistanceStorage = (function() {
 
@@ -17,7 +17,7 @@ var DistanceStorage = (function() {
         );
     }
 
-    // Helper function to calculate the distance between two lat lon points 
+    // Helper function to calculate the distance between two lat lon points
     // using AFSIM's ground range calculation formulas
     function calculateGroundRangeAFSIM(lat1, lon1, lat2, lon2) {
         let pointA = [lat1 * Math.PI/180, lon1 * Math.PI/180, 0];
@@ -78,11 +78,6 @@ var DistanceStorage = (function() {
     // Create a proxy to intercept access to the IIFE
     return new Proxy(originalObject, {
         get(target, prop) {
-            console.log(`DistanceStorage IIFE accessed: ${prop}`);
-            // // Send data to new window
-            // console.log("distance_storage.js >>> sending distanceData to new window");
-            // View.sendDataToNewWindow({type: 'distanceData', data: distanceData});
-            //;
             return target[prop];
         }
     });

--- a/js/missions/mission_generator.js
+++ b/js/missions/mission_generator.js
@@ -1,0 +1,577 @@
+// js/missions/mission_generator.js
+var MissionGenerator = (function() {
+  'use strict';
+
+  var EPSILON = 1e-6;
+  var engagementCounter = 0;
+  var missionCounter = 0;
+  var MAX_MISSIONS_PER_PAIR = 200;
+  var MAX_ENGAGEMENT_OPTIONS_PER_TARGET = 20;
+
+  function log(message) {
+    MissionStorage.addLog(message);
+  }
+
+  function buildWeaponRangeMap() {
+    var weaponRangeMap = {};
+    var weaponData = WeaponStorage.getWeaponData();
+    weaponData.forEach(function(entry) {
+      if (!entry || !entry.weapon_name) {
+        return;
+      }
+      weaponRangeMap[entry.weapon_name] = Number(entry.weapon_range) || 0;
+    });
+    return weaponRangeMap;
+  }
+
+  function buildLethalityMap() {
+    var lethalityMap = {};
+    WeaponLethalityStorage.getLethalityData().forEach(function(entry) {
+      if (!entry || !entry.weapon || !entry.platformType) {
+        return;
+      }
+      var platformType = entry.platformType.trim();
+      if (!platformType) {
+        platformType = 'Unspecified';
+      }
+      if (!lethalityMap[platformType]) {
+        lethalityMap[platformType] = {};
+      }
+      lethalityMap[platformType][entry.weapon.trim()] = Number(entry.quantity) || 0;
+    });
+    return lethalityMap;
+  }
+
+  function buildInventoryForSide(side) {
+    var inventory = {};
+    PlatformModel.getPlatformData().forEach(function(platform) {
+      if (!platform || platform.side !== side) {
+        return;
+      }
+      var weaponMap = {};
+      (platform.weapons || []).forEach(function(weapon) {
+        if (!weapon || !weapon.name) {
+          return;
+        }
+        var quantity = Number(weapon.quantity) || 0;
+        if (quantity > 0) {
+          weaponMap[weapon.name] = quantity;
+        }
+      });
+      inventory[platform.platform_name] = {
+        platform: platform,
+        weapons: weaponMap
+      };
+    });
+    return inventory;
+  }
+
+  function cloneAmmoState(inventory) {
+    var state = {};
+    Object.keys(inventory).forEach(function(platformName) {
+      var weapons = {};
+      Object.keys(inventory[platformName].weapons).forEach(function(weaponName) {
+        weapons[weaponName] = inventory[platformName].weapons[weaponName];
+      });
+      state[platformName] = weapons;
+    });
+    return state;
+  }
+
+  function getContributorList(side, target, weaponRanges, lethalityMap) {
+    var contributors = [];
+    var targetType = (target.type && target.type.trim()) ? target.type.trim() : 'Unspecified';
+    var lethalityForTarget = lethalityMap[targetType];
+
+    if (!lethalityForTarget) {
+      log('No lethality data for target type ' + targetType + ' when evaluating target ' + target.platform_name + '.');
+      return contributors;
+    }
+
+    PlatformModel.getPlatformData().forEach(function(platform) {
+      if (!platform || platform.side !== side) {
+        return;
+      }
+
+      var distance = DistanceStorage.getDistanceBetweenPlatforms(platform.platform_name, target.platform_name);
+      if (distance === null || typeof distance === 'undefined') {
+        log('Missing distance data between ' + platform.platform_name + ' and ' + target.platform_name + '. Engagements skipped.');
+        return;
+      }
+
+      (platform.weapons || []).forEach(function(weapon) {
+        if (!weapon || !weapon.name) {
+          return;
+        }
+
+        var weaponName = weapon.name;
+        var lethalityRequirement = lethalityForTarget[weaponName];
+        if (!lethalityRequirement || lethalityRequirement <= 0) {
+          return;
+        }
+
+        var range = weaponRanges[weaponName];
+        if (!range && range !== 0) {
+          log('Weapon range missing for ' + weaponName + '. Skipping contributor from ' + platform.platform_name + '.');
+          return;
+        }
+
+        if (range < distance) {
+          return;
+        }
+
+        var quantity = Number(weapon.quantity) || 0;
+        if (quantity <= 0) {
+          return;
+        }
+
+        contributors.push({
+          platformName: platform.platform_name,
+          platformType: (platform.type && platform.type.trim()) ? platform.type.trim() : 'Unspecified',
+          weaponName: weaponName,
+          maxShots: quantity,
+          lethalityRequirement: lethalityRequirement,
+          contributionPerShot: 1 / lethalityRequirement,
+          weaponRange: range,
+          distance: distance
+        });
+      });
+    });
+
+    return contributors;
+  }
+
+  function exploreContributors(contributors, target, offensiveSide) {
+    if (!contributors.length) {
+      return [];
+    }
+
+    contributors = contributors.slice().sort(function(a, b) {
+      if (b.contributionPerShot === a.contributionPerShot) {
+        return a.lethalityRequirement - b.lethalityRequirement;
+      }
+      return b.contributionPerShot - a.contributionPerShot;
+    });
+
+    var maxContributionFromIndex = [];
+    var runningTotal = 0;
+    for (var idx = contributors.length - 1; idx >= 0; idx--) {
+      runningTotal += contributors[idx].maxShots * contributors[idx].contributionPerShot;
+      maxContributionFromIndex[idx] = runningTotal;
+    }
+
+    var assignments = [];
+    var bestShotCount = null;
+    var engagements = [];
+
+    function recurse(index, totalContribution, totalShots) {
+      if (index < contributors.length && totalContribution + maxContributionFromIndex[index] < 1 - EPSILON) {
+        return;
+      }
+
+      if (bestShotCount !== null && totalShots > bestShotCount) {
+        return;
+      }
+
+      if (totalContribution >= 1 - EPSILON) {
+        var engagement = createEngagement(target, offensiveSide, assignments, totalContribution);
+        if (!engagement) {
+          return;
+        }
+
+        if (bestShotCount === null || totalShots < bestShotCount) {
+          bestShotCount = totalShots;
+          engagements = [engagement];
+        } else if (totalShots === bestShotCount) {
+          engagements.push(engagement);
+        }
+        return;
+      }
+
+      if (index >= contributors.length) {
+        return;
+      }
+
+      var contributor = contributors[index];
+      var maxShotsNeeded = Math.min(
+        contributor.maxShots,
+        Math.ceil((1 - totalContribution) / contributor.contributionPerShot)
+      );
+
+      for (var count = 0; count <= maxShotsNeeded; count++) {
+        var nextShots = totalShots + count;
+        if (bestShotCount !== null && nextShots > bestShotCount) {
+          break;
+        }
+        if (count > 0) {
+          assignments.push({ contributor: contributor, count: count });
+        }
+        recurse(index + 1, totalContribution + count * contributor.contributionPerShot, nextShots);
+        if (count > 0) {
+          assignments.pop();
+        }
+      }
+    }
+
+    recurse(0, 0, 0);
+    return engagements;
+  }
+
+  function createEngagement(target, offensiveSide, assignments, totalContribution) {
+    if (!assignments.length) {
+      return null;
+    }
+
+    var allocationMap = {};
+    var offensivePlatforms = {};
+
+    assignments.forEach(function(entry) {
+      var contributor = entry.contributor;
+      var key = contributor.platformName + '||' + contributor.weaponName;
+      if (!allocationMap[key]) {
+        allocationMap[key] = {
+          platform: contributor.platformName,
+          platformType: contributor.platformType,
+          weapon: contributor.weaponName,
+          quantity: 0,
+          weaponRange: contributor.weaponRange,
+          distance: contributor.distance,
+          lethalityRequirement: contributor.lethalityRequirement,
+          contribution: 0
+        };
+      }
+      allocationMap[key].quantity += entry.count;
+      allocationMap[key].contribution += entry.count * contributor.contributionPerShot;
+      offensivePlatforms[contributor.platformName] = contributor.platformType;
+    });
+
+    var allocations = Object.keys(allocationMap).map(function(key) {
+      var allocation = allocationMap[key];
+      allocation.contribution = Number(allocation.contribution.toFixed(6));
+      return allocation;
+    }).sort(function(a, b) {
+      if (a.platform === b.platform) {
+        return a.weapon.localeCompare(b.weapon);
+      }
+      return a.platform.localeCompare(b.platform);
+    });
+
+    var totalShots = allocations.reduce(function(sum, allocation) {
+      return sum + allocation.quantity;
+    }, 0);
+
+    engagementCounter += 1;
+
+    return {
+      engagementId: 'engagement-' + engagementCounter,
+      offensiveSide: offensiveSide,
+      targetSide: target.side,
+      targetPlatform: target.platform_name,
+      targetPlatformType: (target.type && target.type.trim()) ? target.type.trim() : 'Unspecified',
+      offensivePlatforms: Object.keys(offensivePlatforms).sort(),
+      weaponAllocations: allocations,
+      totalShots: totalShots,
+      killContribution: Number(totalContribution.toFixed(6)),
+      lethalityRequirementMet: totalContribution + EPSILON >= 1,
+      summary: buildEngagementSummary(target, allocations)
+    };
+  }
+
+  function buildEngagementSummary(target, allocations) {
+    var parts = allocations.map(function(allocation) {
+      return allocation.platform + ' fires ' + allocation.quantity + 'x ' + allocation.weapon;
+    });
+    return parts.join('; ') + ' to destroy ' + target.platform_name;
+  }
+
+  function canApplyEngagement(engagement, ammoState) {
+    return engagement.weaponAllocations.every(function(allocation) {
+      var platformAmmo = ammoState[allocation.platform];
+      if (!platformAmmo) {
+        return false;
+      }
+      var available = platformAmmo[allocation.weapon];
+      return typeof available === 'number' && available >= allocation.quantity;
+    });
+  }
+
+  function applyEngagement(engagement, ammoState) {
+    engagement.weaponAllocations.forEach(function(allocation) {
+      ammoState[allocation.platform][allocation.weapon] -= allocation.quantity;
+    });
+  }
+
+  function revertEngagement(engagement, ammoState) {
+    engagement.weaponAllocations.forEach(function(allocation) {
+      ammoState[allocation.platform][allocation.weapon] += allocation.quantity;
+    });
+  }
+
+  function computeAmmoUsage(engagements) {
+    var usage = {};
+    engagements.forEach(function(engagement) {
+      engagement.weaponAllocations.forEach(function(allocation) {
+        if (!usage[allocation.platform]) {
+          usage[allocation.platform] = {};
+        }
+        if (!usage[allocation.platform][allocation.weapon]) {
+          usage[allocation.platform][allocation.weapon] = 0;
+        }
+        usage[allocation.platform][allocation.weapon] += allocation.quantity;
+      });
+    });
+    return usage;
+  }
+
+  function cloneEngagement(engagement) {
+    return {
+      engagementId: engagement.engagementId,
+      offensiveSide: engagement.offensiveSide,
+      targetSide: engagement.targetSide,
+      targetPlatform: engagement.targetPlatform,
+      targetPlatformType: engagement.targetPlatformType,
+      offensivePlatforms: engagement.offensivePlatforms.slice(),
+      weaponAllocations: engagement.weaponAllocations.map(function(allocation) {
+        return {
+          platform: allocation.platform,
+          platformType: allocation.platformType,
+          weapon: allocation.weapon,
+          quantity: allocation.quantity,
+          weaponRange: allocation.weaponRange,
+          distance: allocation.distance,
+          lethalityRequirement: allocation.lethalityRequirement,
+          contribution: allocation.contribution
+        };
+      }),
+      totalShots: engagement.totalShots,
+      killContribution: engagement.killContribution,
+      lethalityRequirementMet: engagement.lethalityRequirementMet,
+      summary: engagement.summary
+    };
+  }
+
+  function mapToPlatformWeaponArray(map) {
+    return Object.keys(map).sort().map(function(platform) {
+      var weapons = map[platform];
+      return {
+        platform: platform,
+        weapons: Object.keys(weapons).sort().map(function(weapon) {
+          return {
+            weapon: weapon,
+            quantity: weapons[weapon]
+          };
+        })
+      };
+    });
+  }
+
+  function computeRemainingAmmo(inventory, usage) {
+    var remaining = {};
+    Object.keys(inventory).forEach(function(platformName) {
+      remaining[platformName] = {};
+      Object.keys(inventory[platformName].weapons).forEach(function(weaponName) {
+        var total = inventory[platformName].weapons[weaponName];
+        var used = (usage[platformName] && usage[platformName][weaponName]) || 0;
+        remaining[platformName][weaponName] = total - used;
+      });
+    });
+    return remaining;
+  }
+
+  function buildMissionObject(side, enemySide, engagements, inventory) {
+    missionCounter += 1;
+    var missionId = 'mission-' + missionCounter;
+
+    var targetsDestroyed = engagements.map(function(engagement) {
+      return engagement.targetPlatform;
+    });
+    var targetTypes = {};
+    var offensivePlatforms = {};
+    var offensivePlatformTypes = {};
+    var weaponSummary = {};
+
+    engagements.forEach(function(engagement) {
+      targetTypes[engagement.targetPlatformType] = true;
+      engagement.offensivePlatforms.forEach(function(platformName) {
+        offensivePlatforms[platformName] = true;
+      });
+      engagement.weaponAllocations.forEach(function(allocation) {
+        offensivePlatformTypes[allocation.platformType || 'Unspecified'] = true;
+        if (!weaponSummary[allocation.weapon]) {
+          weaponSummary[allocation.weapon] = {
+            weapon: allocation.weapon,
+            quantity: 0,
+            platforms: {}
+          };
+        }
+        weaponSummary[allocation.weapon].quantity += allocation.quantity;
+        weaponSummary[allocation.weapon].platforms[allocation.platform] = true;
+      });
+    });
+
+    var weaponSummaryArray = Object.keys(weaponSummary).sort().map(function(weaponName) {
+      var entry = weaponSummary[weaponName];
+      return {
+        weapon: entry.weapon,
+        quantity: entry.quantity,
+        platforms: Object.keys(entry.platforms).sort()
+      };
+    });
+
+    var ammoUsage = computeAmmoUsage(engagements);
+    var remainingAmmo = computeRemainingAmmo(inventory, ammoUsage);
+    var totalAmmoExpended = weaponSummaryArray.reduce(function(sum, entry) {
+      return sum + entry.quantity;
+    }, 0);
+
+    return {
+      missionId: missionId,
+      offensiveSide: side,
+      enemySide: enemySide,
+      destroyedPlatformCount: engagements.length,
+      engagementCount: engagements.length,
+      targetsDestroyed: targetsDestroyed,
+      targetTypesDestroyed: Object.keys(targetTypes).sort(),
+      offensivePlatforms: Object.keys(offensivePlatforms).sort(),
+      offensivePlatformTypes: Object.keys(offensivePlatformTypes).sort(),
+      weaponsUsed: weaponSummaryArray,
+      totalAmmoExpended: totalAmmoExpended,
+      ammoExpendedByPlatform: mapToPlatformWeaponArray(ammoUsage),
+      remainingAmmoByPlatform: mapToPlatformWeaponArray(remainingAmmo),
+      engagements: engagements.map(cloneEngagement)
+    };
+  }
+
+  function generateMissionsForSides(side, enemySide, weaponRanges, lethalityMap) {
+    var inventory = buildInventoryForSide(side);
+    var ammoState = cloneAmmoState(inventory);
+    var enemyPlatforms = PlatformModel.getPlatformData().filter(function(platform) {
+      return platform.side === enemySide;
+    }).sort(function(a, b) {
+      return a.platform_name.localeCompare(b.platform_name);
+    });
+
+    var engagementOptionsByTarget = {};
+    enemyPlatforms.forEach(function(target) {
+      log('Evaluating target ' + target.platform_name + ' (' + enemySide + ') for offensive side ' + side + '.');
+      var contributors = getContributorList(side, target, weaponRanges, lethalityMap);
+      var engagements = exploreContributors(contributors, target, side);
+      if (engagements.length > MAX_ENGAGEMENT_OPTIONS_PER_TARGET) {
+        var originalCount = engagements.length;
+        engagements = engagements.sort(function(a, b) {
+          if (a.totalShots === b.totalShots) {
+            return a.weaponAllocations.length - b.weaponAllocations.length;
+          }
+          return a.totalShots - b.totalShots;
+        }).slice(0, MAX_ENGAGEMENT_OPTIONS_PER_TARGET);
+        log('Engagement options for target ' + target.platform_name + ' limited to ' + MAX_ENGAGEMENT_OPTIONS_PER_TARGET + ' (from ' + originalCount + ' minimal combinations).');
+      }
+      if (!engagements.length) {
+        log('No engagement options found for target ' + target.platform_name + ' by side ' + side + '.');
+      } else {
+        log('Generated ' + engagements.length + ' engagement option(s) for target ' + target.platform_name + ' by side ' + side + '.');
+      }
+      engagementOptionsByTarget[target.platform_name] = engagements;
+    });
+
+    var targets = enemyPlatforms.map(function(platform) {
+      return platform.platform_name;
+    });
+
+    var engagementsBuffer = [];
+    var missionCountForPair = 0;
+    var missionLimitReached = false;
+
+    function backtrack(targetIndex) {
+      if (missionLimitReached) {
+        return;
+      }
+
+      if (targetIndex >= targets.length) {
+        if (engagementsBuffer.length > 0) {
+          var mission = buildMissionObject(side, enemySide, engagementsBuffer, inventory);
+          MissionStorage.addMission(mission);
+          missionCountForPair += 1;
+          if (missionCountForPair >= MAX_MISSIONS_PER_PAIR) {
+            missionLimitReached = true;
+          }
+        }
+        return;
+      }
+
+      var targetName = targets[targetIndex];
+      var options = engagementOptionsByTarget[targetName] || [];
+
+      // Option: skip this target entirely
+      backtrack(targetIndex + 1);
+      if (missionLimitReached) {
+        return;
+      }
+
+      options.forEach(function(option) {
+        if (!canApplyEngagement(option, ammoState)) {
+          return;
+        }
+        applyEngagement(option, ammoState);
+        engagementsBuffer.push(option);
+        backtrack(targetIndex + 1);
+        engagementsBuffer.pop();
+        revertEngagement(option, ammoState);
+        if (missionLimitReached) {
+          return;
+        }
+      });
+    }
+
+    backtrack(0);
+
+    if (missionLimitReached) {
+      log('Mission generation limit of ' + MAX_MISSIONS_PER_PAIR + ' reached for side ' + side + ' vs ' + enemySide + '. Additional combinations were not recorded.');
+    }
+
+    log('Completed mission generation for side ' + side + ' vs ' + enemySide + '. Total missions: ' + MissionStorage.getMissions().length + '.');
+  }
+
+  function generateAllMissions() {
+    MissionStorage.clearAll();
+    engagementCounter = 0;
+    missionCounter = 0;
+
+    var weaponRanges = buildWeaponRangeMap();
+    var lethalityMap = buildLethalityMap();
+    var platformData = PlatformModel.getPlatformData();
+
+    var sides = {};
+    platformData.forEach(function(platform) {
+      if (platform && platform.side) {
+        sides[platform.side] = true;
+      }
+    });
+
+    var sideList = Object.keys(sides);
+    if (!sideList.length) {
+      log('No sides available to generate missions.');
+      return [];
+    }
+
+    sideList.forEach(function(offensiveSide) {
+      var enemySides = sideList.filter(function(side) {
+        return side !== offensiveSide;
+      });
+      if (!enemySides.length) {
+        log('Side ' + offensiveSide + ' has no opposing sides. Skipping mission generation for this side.');
+        return;
+      }
+
+      enemySides.forEach(function(enemySide) {
+        generateMissionsForSides(offensiveSide, enemySide, weaponRanges, lethalityMap);
+      });
+    });
+
+    return MissionStorage.getMissions();
+  }
+
+  return {
+    generateAllMissions: generateAllMissions
+  };
+})();

--- a/js/missions/mission_storage.js
+++ b/js/missions/mission_storage.js
@@ -1,0 +1,51 @@
+// js/missions/mission_storage.js
+var MissionStorage = (function() {
+  var missions = [];
+  var logs = [];
+
+  function addMission(mission) {
+    missions.push(mission);
+  }
+
+  function getMissions() {
+    return missions.slice();
+  }
+
+  function clearMissions() {
+    missions = [];
+  }
+
+  function addLog(entry) {
+    if (typeof entry === 'string' && entry.trim().length > 0) {
+      logs.push(entry);
+    }
+  }
+
+  function getLogs() {
+    return logs.slice();
+  }
+
+  function clearLogs() {
+    logs = [];
+  }
+
+  function clearAll() {
+    clearMissions();
+    clearLogs();
+  }
+
+  function exportData() {
+    return JSON.stringify(missions, null, 2);
+  }
+
+  return {
+    addMission: addMission,
+    getMissions: getMissions,
+    clearMissions: clearMissions,
+    addLog: addLog,
+    getLogs: getLogs,
+    clearLogs: clearLogs,
+    clearAll: clearAll,
+    exportData: exportData
+  };
+})();

--- a/missions.html
+++ b/missions.html
@@ -5,30 +5,33 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>WALT Missions</title>
 
-  <!-- External Libraries -->
   <link rel="stylesheet" href="libs/jquery/jquery-ui.css">
-
-  <!-- Custom Stylesheets -->
   <link rel="stylesheet" href="missions/css/missions.css">
 </head>
 <body>
   <header class="missions-header">
     <h1>Missions</h1>
-    <p class="missions-subtitle">This page is ready for mission planning features.</p>
+    <p class="missions-subtitle">Generated mission combinations based on the current scenario.</p>
   </header>
 
-  <main id="missions-root" class="missions-content" aria-live="polite">
-    <section class="missions-placeholder">
-      <h2>Placeholder</h2>
-      <p>Use <code>missions/js/missions.js</code> for behavior and <code>missions/css/missions.css</code> for styling.</p>
-    </section>
-  </main>
+  <main id="missions-root" class="missions-content" aria-live="polite"></main>
 
-  <!-- External Scripts -->
   <script src="libs/jquery/jquery.min.js"></script>
   <script src="libs/jquery/jquery-ui.js"></script>
+  <script src="libs/geo/geolib.min.js"></script>
+  <script src="libs/custom/GroundRange.js"></script>
 
-  <!-- Page Scripts -->
+  <script src="input/platform_details.js"></script>
+  <script src="input/weapon_details.js"></script>
+  <script src="input/weapon_lethality_details.js"></script>
+
+  <script src="js/platforms/platform_model.js"></script>
+  <script src="js/weapons/weapon_storage.js"></script>
+  <script src="js/weapon_lethality/weapon_lethality_storage.js"></script>
+  <script src="js/distance_storage.js"></script>
+  <script src="js/missions/mission_storage.js"></script>
+  <script src="js/missions/mission_generator.js"></script>
+
   <script src="missions/js/missions.js"></script>
 </body>
 </html>

--- a/missions/css/missions.css
+++ b/missions/css/missions.css
@@ -1,7 +1,7 @@
 body {
   margin: 0;
   font-family: Arial, Helvetica, sans-serif;
-  background-color: #ffffff;
+  background-color: #f5f7fb;
   color: #1f2933;
   min-height: 100vh;
   display: flex;
@@ -11,6 +11,7 @@ body {
 .missions-header {
   padding: 1.5rem 1rem;
   border-bottom: 1px solid #d9e1f1;
+  background-color: #ffffff;
 }
 
 .missions-header h1 {
@@ -26,24 +27,70 @@ body {
 
 .missions-content {
   flex: 1;
-  padding: 2rem 1rem;
-}
-
-.missions-placeholder {
-  max-width: 640px;
+  padding: 2rem 1rem 3rem;
+  max-width: 1100px;
+  width: 100%;
   margin: 0 auto;
-  padding: 1.5rem;
-  border: 1px dashed #c8d2e4;
-  border-radius: 6px;
-  background-color: #ffffff;
+  box-sizing: border-box;
 }
 
-.missions-placeholder h2 {
+.missions-summary,
+.missions-section {
+  background-color: #ffffff;
+  border: 1px solid #d9e1f1;
+  border-radius: 6px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 1px 2px rgba(31, 41, 51, 0.06);
+}
+
+.missions-summary h2,
+.missions-section h2 {
   margin-top: 0;
   font-size: 1.25rem;
+  color: #1f2933;
 }
 
-.missions-placeholder p {
-  margin-bottom: 0;
-  line-height: 1.5;
+.missions-summary p {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.missions-textarea {
+  width: 100%;
+  min-height: 320px;
+  resize: vertical;
+  padding: 1rem;
+  border-radius: 4px;
+  border: 1px solid #c8d2e4;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  background-color: #fdfdfd;
+  box-sizing: border-box;
+}
+
+.missions-textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+.missions-log {
+  min-height: 200px;
+}
+
+@media (max-width: 768px) {
+  .missions-content {
+    padding: 1.5rem 1rem 2rem;
+  }
+
+  .missions-summary,
+  .missions-section {
+    padding: 1.25rem;
+  }
+
+  .missions-textarea {
+    min-height: 240px;
+  }
 }

--- a/missions/js/missions.js
+++ b/missions/js/missions.js
@@ -1,13 +1,80 @@
 (function () {
   'use strict';
 
+  function initializeData() {
+    if (typeof PLATFORM_DATA === 'undefined' || typeof WEAPON_DATA === 'undefined' || typeof WEAPON_LETHALITY_DATA === 'undefined') {
+      MissionStorage.addLog('Scenario data not found. Ensure input data files are loaded.');
+      return false;
+    }
+
+    PlatformModel.loadInitialData(PLATFORM_DATA);
+    WeaponStorage.loadInitialData(WEAPON_DATA);
+    WeaponLethalityStorage.loadInitialData(WEAPON_LETHALITY_DATA);
+    DistanceStorage.initializeDistanceData();
+    return true;
+  }
+
+  function renderResults(root, missions, logs) {
+    var missionCount = missions.length;
+
+    root.innerHTML = '';
+
+    var summarySection = document.createElement('section');
+    summarySection.className = 'missions-summary';
+    summarySection.innerHTML = `
+      <h2>Mission Generation Summary</h2>
+      <p><strong>Total missions:</strong> <span>${missionCount}</span></p>
+    `;
+    root.appendChild(summarySection);
+
+    var missionsSection = document.createElement('section');
+    missionsSection.className = 'missions-section';
+    missionsSection.innerHTML = '<h2>Generated Missions</h2>';
+    var missionsTextarea = document.createElement('textarea');
+    missionsTextarea.className = 'missions-textarea';
+    missionsTextarea.readOnly = true;
+    missionsTextarea.value = missionCount ? JSON.stringify(missions, null, 2) : 'No missions generated.';
+    missionsSection.appendChild(missionsTextarea);
+    root.appendChild(missionsSection);
+
+    var logSection = document.createElement('section');
+    logSection.className = 'missions-section';
+    logSection.innerHTML = '<h2>Generation Log</h2>';
+    var logTextarea = document.createElement('textarea');
+    logTextarea.className = 'missions-textarea missions-log';
+    logTextarea.readOnly = true;
+    logTextarea.value = logs.length ? logs.join('\n') : 'No log messages.';
+    logSection.appendChild(logTextarea);
+    root.appendChild(logSection);
+  }
+
   document.addEventListener('DOMContentLoaded', function () {
-    const root = document.getElementById('missions-root');
+    var root = document.getElementById('missions-root');
     if (!root) {
       return;
     }
 
-    // Placeholder hook for future mission planning modules.
+    MissionStorage.clearAll();
+
+    var initialized = false;
+    try {
+      initialized = initializeData();
+    } catch (error) {
+      MissionStorage.addLog('Initialization error: ' + (error && error.message ? error.message : error));
+    }
+
+    var missions = [];
+    if (initialized) {
+      try {
+        missions = MissionGenerator.generateAllMissions();
+      } catch (error) {
+        MissionStorage.addLog('Mission generation error: ' + (error && error.message ? error.message : error));
+      }
+    }
+
+    var logs = MissionStorage.getLogs();
+    renderResults(root, missions, logs);
+
     root.dataset.ready = 'true';
   });
 })();


### PR DESCRIPTION
## Summary
- add mission storage and generation modules to build engagements from platform, weapon, lethality, and distance data
- update the missions page to initialize storages, run the generator, and render JSON plus build logs
- refresh the missions styling and load required scripts while trimming distance storage debug logging

## Testing
- Manual: Loaded `missions.html` via a local HTTP server and verified the generated mission JSON output

------
https://chatgpt.com/codex/tasks/task_e_68e7886ab15c832abc72c735d13d6694