### PR TITLE
Open Missions page in new tab with noopener

### DIFF
--- a/js/view.js
+++ b/js/view.js
@@ -159,7 +159,7 @@ var View = (function() {
 
         // Navigate to the Missions page when requested
         document.getElementById('missionsButton').addEventListener('click', function () {
-            window.location.href = 'missions.html';
+            window.open('missions.html', '_blank', 'noopener');
         });
 
     }


### PR DESCRIPTION
### Motivation
- Prevent navigation away from the main app when opening the Missions page by opening it in a new tab and avoid exposing `window.opener` for security.

### Description
- Replace `window.location.href = 'missions.html';` with `window.open('missions.html', '_blank', 'noopener');` in the Missions button handler so the page opens in a new tab with `noopener`.

### Testing
- Ran the project's automated test suite and linters against the modified code and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022876c5ac832aa1b81c82c8ea079f)