### PR TITLE
Add WALT logo and header layout/styles to platform table

### DIFF
--- a/css/walt-menu-styles.css
+++ b/css/walt-menu-styles.css
@@ -49,6 +49,24 @@
     flex: 0 0 auto;
 }
 
+#platformTableContainer .platform-table-title-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+#platformTableContainer .platform-table-logo {
+    width: 32px;
+    height: 32px;
+    object-fit: contain;
+    flex: 0 0 auto;
+}
+
+#platformTableContainer .platform-table-title {
+    margin: 0;
+    line-height: 1.2;
+}
+
 #platformTableContainer .platform-table-toolbar {
     display: flex;
     justify-content: space-between;

--- a/index.html
+++ b/index.html
@@ -66,7 +66,16 @@
     <!-- Platform Table and Controls Container -->
     <div id="platformTableContainer">
       <div class="platform-table-header">
-        <h2 class="platform-table-title">Warfighting Analysis Laydown Tool (WALT)</h2>
+        <div class="platform-table-title-row">
+          <img
+            src="images/art/WALT_LOGO.png"
+            alt="WALT logo"
+            class="platform-table-logo"
+            width="32"
+            height="32"
+          >
+          <h2 class="platform-table-title">Warfighting Analysis Laydown Tool (WALT)</h2>
+        </div>
         <div class="platform-table-toolbar">
           <h3 class="platform-table-subtitle">Platforms</h3>
           <div class="platform-table-toolbar-actions">


### PR DESCRIPTION
### Motivation
- Improve the platform table header by adding a recognizable WALT logo and cleaner header layout to make the UI more visually informative and compact.

### Description
- Add an inline logo and title row in `index.html` by wrapping the title in a new `.platform-table-title-row` and inserting an `img` with class `.platform-table-logo` next to the `h2` title.
- Add CSS rules in `css/walt-menu-styles.css` for `.platform-table-title-row`, `.platform-table-logo`, and `.platform-table-title` to control alignment, sizing, and spacing of the new header elements.
- Keep all existing toolbar and table structures intact with no JavaScript changes required for the static header update.

### Testing
- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06283ab68c832ab9afb8bf42b9eeef)