### PR TITLE
Add 'Icons' button left of Columns in platform toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,13 @@
           <div class="platform-table-toolbar-actions">
             <button
               type="button"
+              id="iconToggleButton"
+              class="column-toggle-button"
+            >
+              Icons
+            </button>
+            <button
+              type="button"
               id="columnToggleButton"
               class="column-toggle-button"
               aria-haspopup="true"


### PR DESCRIPTION
### Motivation
- Add a new `Icons` button immediately to the left of the existing `Columns` button in the platform toolbar so it is visually available with the same styling for future functionality.

### Description
- Inserted a new `<button id="iconToggleButton" class="column-toggle-button">Icons</button>` in `index.html` directly before the existing `columnToggleButton`, reusing the `column-toggle-button` class so styling matches exactly and no behavior was added.

### Testing
- Verified the updated HTML snippet with `nl -ba index.html | sed -n '66,95p'`, confirmed the diff with `git diff -- index.html`, and successfully committed the change with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06fc826f30832aaeca2204e7aab279)