### PR TITLE
Add Icons button beside Columns control

### DIFF
--- a/css/walt-menu-styles.css
+++ b/css/walt-menu-styles.css
@@ -60,6 +60,7 @@
     position: relative;
     display: flex;
     align-items: center;
+    gap: 6px;
 }
 
 #platformTableContainer .column-toggle-button {

--- a/index.html
+++ b/index.html
@@ -70,6 +70,9 @@
         <div class="platform-table-toolbar">
           <h3 class="platform-table-subtitle">Platforms</h3>
           <div class="platform-table-toolbar-actions">
+            <button type="button" id="iconsButton" class="column-toggle-button">
+              Icons
+            </button>
             <button
               type="button"
               id="columnToggleButton"


### PR DESCRIPTION
### Motivation
- Provide an "Icons" control immediately to the left of the existing "Columns" button in the platform table toolbar so the UI can offer an icons-related action with identical visual styling to the Columns control.

### Description
- Inserted a new button element with `id="iconsButton"` and the shared `column-toggle-button` class into `index.html` directly before the existing Columns button.
- Added a small spacing rule (`gap: 6px;`) to `#platformTableContainer .platform-table-toolbar-actions` in `css/walt-menu-styles.css` so adjacent toolbar buttons are visually separated while keeping identical per-button styles.
- No JavaScript behavior was added for the new `Icons` button in this change; this is a markup/styling-only update.

### Testing
- Ran file searches and inspected the modified files with `rg` and `nl` to verify the new markup and style were present, and those checks succeeded.
- Executed `git add index.html css/walt-menu-styles.css && git commit -m "Add Icons button beside Columns control"` to persist the change and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06fc826f30832aaeca2204e7aab279)