### PR TITLE
Normalize icon URLs and add DMD_ prefix for red side icons

### DIFF
--- a/js/config/side_config.js
+++ b/js/config/side_config.js
@@ -96,7 +96,7 @@
 
         if (trimmed.indexOf(ICONS_BASE_PATH) === 0) {
             var filename = trimmed.slice(ICONS_BASE_PATH.length);
-            if (/^[^/]+\.png$/i.test(filename) && filename.indexOf('plat_') !== 0) {
+            if (/^[^/]+\.png$/i.test(filename) && filename.indexOf('plat_') !== 0 && filename.indexOf('DMD_plat_') !== 0) {
                 filename = 'plat_' + filename;
             }
 

--- a/js/config/side_config.js
+++ b/js/config/side_config.js
@@ -85,7 +85,7 @@
     var STORAGE_KEY = 'walt.sideIconOverrides';
     var ICONS_BASE_PATH = 'images/colored-icons/surface-icons/';
 
-    function normalizeIconUrl(iconUrl) {
+    function normalizeIconUrl(iconUrl, sideId) {
         if (typeof iconUrl !== 'string') {
             return '';
         }
@@ -97,8 +97,14 @@
         if (trimmed.indexOf(ICONS_BASE_PATH) === 0) {
             var filename = trimmed.slice(ICONS_BASE_PATH.length);
             if (/^[^/]+\.png$/i.test(filename) && filename.indexOf('plat_') !== 0) {
-                return ICONS_BASE_PATH + 'plat_' + filename;
+                filename = 'plat_' + filename;
             }
+
+            if (sideId === 'red' && filename.indexOf('DMD_') !== 0) {
+                filename = 'DMD_' + filename;
+            }
+
+            return ICONS_BASE_PATH + filename;
         }
 
         return trimmed;
@@ -122,7 +128,7 @@
 
             Object.keys(parsed).forEach(function(sideId) {
                 var iconUrl = parsed[sideId];
-                var normalizedIconUrl = normalizeIconUrl(iconUrl);
+                var normalizedIconUrl = normalizeIconUrl(iconUrl, sideId);
                 if (!sideMap[sideId] || !normalizedIconUrl) {
                     return;
                 }
@@ -210,7 +216,7 @@
     }
 
     function setIconForSide(id, iconUrl) {
-        var normalizedIconUrl = normalizeIconUrl(iconUrl);
+        var normalizedIconUrl = normalizeIconUrl(iconUrl, id);
         if (typeof id !== 'string' || !sideMap[id] || !normalizedIconUrl) {
             return false;
         }

--- a/js/table_controller.js
+++ b/js/table_controller.js
@@ -299,7 +299,8 @@ var TableController = (function() {
 
             Object.keys(ICON_COLOR_OPTIONS).forEach(function(colorName) {
                 var rgb = ICON_COLOR_OPTIONS[colorName];
-                var iconPath = 'images/colored-icons/surface-icons/plat_' + colorName + '.png';
+                var iconFilenamePrefix = sideId === 'red' ? 'DMD_plat_' : 'plat_';
+                var iconPath = 'images/colored-icons/surface-icons/' + iconFilenamePrefix + colorName + '.png';
                 var $swatch = $('<button></button>', {
                     type: 'button',
                     'class': 'icon-color-swatch',


### PR DESCRIPTION
### Motivation

- Ensure icon filenames are normalized consistently and that red-side icons use the expected `DMD_` filename prefix so UI selections and stored overrides resolve to the correct asset paths.

### Description

- Change `normalizeIconUrl` signature to accept `sideId` and adjust normalization logic to add `plat_` when missing and to prepend `DMD_` for the `'red'` side before returning a full `ICONS_BASE_PATH` path.
- Pass `sideId` into `normalizeIconUrl` from `loadIconOverrides` and `setIconForSide` so persisted overrides are normalized correctly for each side.
- Update the icons menu in `table_controller.js` to construct icon filenames with a `DMD_plat_` prefix for the `'red'` side and `plat_` for others so the swatches match the normalization rules.

### Testing

- Ran the JavaScript frontend test suite via `npm test`, and the suite completed successfully.
- Ran the linter via `npm run lint`, and no linting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0725935bc8832a95a0f9cc485cee01)