### PR TITLE
Persist range ring style templates and prevent duplicate names

### DIFF
--- a/js/range_rings/range_ring_style_editor.js
+++ b/js/range_rings/range_ring_style_editor.js
@@ -7,11 +7,16 @@ var RangeRingStyleEditor = (function() {
 
   var templates = [];
   var selectedTemplateIndex = 0;
+  var TEMPLATE_STORAGE_KEY = 'walt.rangeRingStyleTemplates';
 
   function initTemplates() {
-    var incoming = Array.isArray(window.range_ring_style_templates)
-      ? window.range_ring_style_templates
-      : [];
+    var incoming = loadStoredTemplates();
+
+    if (!incoming.length) {
+      incoming = Array.isArray(window.range_ring_style_templates)
+        ? window.range_ring_style_templates
+        : [];
+    }
 
     templates = incoming.map(function(template) {
       return normalizeTemplate(template);
@@ -107,8 +112,14 @@ var RangeRingStyleEditor = (function() {
       if (!template) {
         return;
       }
+      if (hasDuplicateTemplateName(template.name)) {
+        alert('A template with this name already exists. Please choose a unique name.');
+        return;
+      }
+
       templates.push(template);
       selectedTemplateIndex = templates.length - 1;
+      persistTemplates();
       renderTemplateSelect();
       loadTemplateIntoInputs(selectedTemplateIndex);
     });
@@ -124,7 +135,13 @@ var RangeRingStyleEditor = (function() {
       if (!template) {
         return;
       }
+      if (hasDuplicateTemplateName(template.name, selectedTemplateIndex)) {
+        alert('A template with this name already exists. Please choose a unique name.');
+        return;
+      }
+
       templates[selectedTemplateIndex] = template;
+      persistTemplates();
       RangeRingLogic.applyStyleToToggledRangeRings(template);
       $('#rangeRingStyleDialog').dialog('close');
       $('#rangeRingInfoDialog').dialog('close');
@@ -193,6 +210,56 @@ var RangeRingStyleEditor = (function() {
     ctx.globalAlpha = clamp(template.opacity, 0, 1);
     ctx.stroke();
     ctx.globalAlpha = 1;
+  }
+
+
+  function loadStoredTemplates() {
+    if (!window.localStorage) {
+      return [];
+    }
+
+    try {
+      var rawValue = window.localStorage.getItem(TEMPLATE_STORAGE_KEY);
+      if (!rawValue) {
+        return [];
+      }
+
+      var parsed = JSON.parse(rawValue);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+      console.warn('range_ring_style_editor.js: failed to load stored templates', error);
+      return [];
+    }
+  }
+
+  function persistTemplates() {
+    window.range_ring_style_templates = templates.map(function(template) {
+      return Object.assign({}, template);
+    });
+
+    if (!window.localStorage) {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(TEMPLATE_STORAGE_KEY, JSON.stringify(window.range_ring_style_templates));
+    } catch (error) {
+      console.warn('range_ring_style_editor.js: failed to persist templates', error);
+    }
+  }
+
+  function hasDuplicateTemplateName(name, ignoreIndex) {
+    var normalizedName = String(name || '').trim().toLowerCase();
+    if (!normalizedName) {
+      return false;
+    }
+
+    return templates.some(function(template, index) {
+      if (index === ignoreIndex) {
+        return false;
+      }
+      return String(template.name || '').trim().toLowerCase() === normalizedName;
+    });
   }
 
   function copyTemplatesToClipboard() {


### PR DESCRIPTION
### Motivation
- Templates added in the range ring style editor were only stored in a dialog-local array and lost when the dialog closed, so templates did not persist across dialog sessions or page reloads.
- Users were allowed to create templates with duplicate names, causing confusion when selecting templates.

### Description
- Load templates from `localStorage` first (key `walt.rangeRingStyleTemplates`) with fallback to the existing global `window.range_ring_style_templates` array in `js/range_rings/range_ring_style_editor.js` via `loadStoredTemplates()`.
- Persist changes to both the in-memory `window.range_ring_style_templates` and `localStorage` using a new `persistTemplates()` function when adding or applying a template.
- Add `hasDuplicateTemplateName()` to block duplicate template names (case-insensitive, trimmed) and enforce this check when creating a new template and when applying/renaming an existing template.
- Keep previous behavior for rendering and previewing templates; no API surface changes outside the editor file.

### Testing
- Repository verification and metadata operations (staging/commit and PR metadata creation) completed successfully after the change.
- Confirmed the editor now calls `persistTemplates()` from the Add and Apply flows and that `loadStoredTemplates()` is used on dialog open via simple static analysis of the modified file (`js/range_rings/range_ring_style_editor.js`).
- No automated unit test suite was present or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073b809fcc832aa356299e6f6e92c2)