### PR TITLE
Add RangeUtils for normalized range bands and wire into weapons/sensors and UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,6 +155,7 @@
   <!-------------------------------------------------------------------------->
   <!-- Storage Scripts -->
   <script src="js/platforms/platform_model.js"></script>
+  <script src="js/range_utils.js"></script>
   <script src="js/weapons/weapon_storage.js"></script>
   <script src="js/weapon_lethality/weapon_lethality_storage.js"></script>
   <script src="js/sensors/sensor_storage.js"></script>

--- a/js/range_utils.js
+++ b/js/range_utils.js
@@ -1,0 +1,207 @@
+// range_utils.js
+// Shared helpers for normalizing, validating, formatting, and evaluating
+// minimum/maximum range bands for weapons, sensors, and range-aware features.
+var RangeUtils = (function() {
+    var DEFAULT_MIN_RANGE = 0;
+
+    function firstDefined(values) {
+        for (var i = 0; i < values.length; i++) {
+            if (values[i] !== undefined && values[i] !== null && values[i] !== '') {
+                return values[i];
+            }
+        }
+        return undefined;
+    }
+
+    function parseRange(value) {
+        if (value === undefined || value === null || value === '') {
+            return null;
+        }
+
+        var parsed = Number(value);
+        return isFinite(parsed) ? parsed : null;
+    }
+
+    function clampMinimum(value, minimum) {
+        return value < minimum ? minimum : value;
+    }
+
+    function getRawRangeValue(record, fieldNames) {
+        if (!record) {
+            return undefined;
+        }
+        return firstDefined(fieldNames.map(function(fieldName) {
+            return record[fieldName];
+        }));
+    }
+
+    function getRangeBand(record, options) {
+        options = options || {};
+        var minFieldNames = options.minFieldNames || ['min_range'];
+        var maxFieldNames = options.maxFieldNames || ['max_range', 'range'];
+        var defaultMinRange = options.defaultMinRange !== undefined ? options.defaultMinRange : DEFAULT_MIN_RANGE;
+
+        var minRange = parseRange(getRawRangeValue(record, minFieldNames));
+        var maxRange = parseRange(getRawRangeValue(record, maxFieldNames));
+
+        if (minRange === null) {
+            minRange = defaultMinRange;
+        }
+
+        return {
+            min: minRange,
+            max: maxRange,
+            isValid: isValidRangeBand(minRange, maxRange)
+        };
+    }
+
+    function getWeaponRangeBand(weapon) {
+        return getRangeBand(weapon, {
+            minFieldNames: ['weapon_min_range', 'min_range'],
+            maxFieldNames: ['weapon_max_range', 'max_range', 'weapon_range']
+        });
+    }
+
+    function getSensorRangeBand(sensor) {
+        return getRangeBand(sensor, {
+            minFieldNames: ['sensor_min_range', 'min_range'],
+            maxFieldNames: ['sensor_max_range', 'max_range', 'sensor_range']
+        });
+    }
+
+    function isValidRangeBand(minRange, maxRange) {
+        return isFinite(minRange) &&
+            isFinite(maxRange) &&
+            minRange >= 0 &&
+            maxRange >= 0 &&
+            minRange <= maxRange;
+    }
+
+    function validateRangeBand(minRange, maxRange) {
+        var errors = [];
+
+        if (!isFinite(minRange)) {
+            errors.push('Minimum range must be a numeric value.');
+        }
+        if (!isFinite(maxRange)) {
+            errors.push('Maximum range must be a numeric value.');
+        }
+        if (isFinite(minRange) && minRange < 0) {
+            errors.push('Minimum range cannot be negative.');
+        }
+        if (isFinite(maxRange) && maxRange < 0) {
+            errors.push('Maximum range cannot be negative.');
+        }
+        if (isFinite(minRange) && isFinite(maxRange) && minRange > maxRange) {
+            errors.push('Minimum range cannot be greater than maximum range.');
+        }
+
+        return {
+            isValid: errors.length === 0,
+            errors: errors
+        };
+    }
+
+    function normalizeRangeBand(record, options) {
+        options = options || {};
+        var band = getRangeBand(record, options);
+        var minRange = parseRange(band.min);
+        var maxRange = parseRange(band.max);
+
+        if (minRange === null) {
+            minRange = options.defaultMinRange !== undefined ? options.defaultMinRange : DEFAULT_MIN_RANGE;
+        }
+
+        if (options.clampToZero !== false) {
+            minRange = clampMinimum(minRange, 0);
+            if (maxRange !== null) {
+                maxRange = clampMinimum(maxRange, 0);
+            }
+        }
+
+        if (maxRange === null) {
+            maxRange = minRange;
+        }
+
+        return {
+            min: minRange,
+            max: maxRange,
+            isValid: isValidRangeBand(minRange, maxRange),
+            validation: validateRangeBand(minRange, maxRange)
+        };
+    }
+
+    function normalizeWeaponRecord(weapon) {
+        var normalized = Object.assign({}, weapon || {});
+        var band = normalizeRangeBand(normalized, {
+            minFieldNames: ['weapon_min_range', 'min_range'],
+            maxFieldNames: ['weapon_max_range', 'max_range', 'weapon_range']
+        });
+
+        normalized.weapon_min_range = band.min;
+        normalized.weapon_max_range = band.max;
+
+        // Keep the legacy scalar field synchronized with the canonical maximum
+        // range during the migration period so existing range-ring,
+        // configuration, and results code continues to operate until later
+        // phases switch to the canonical min/max fields.
+        normalized.weapon_range = band.max;
+
+        return normalized;
+    }
+
+    function normalizeSensorRecord(sensor) {
+        var normalized = Object.assign({}, sensor || {});
+        var band = normalizeRangeBand(normalized, {
+            minFieldNames: ['sensor_min_range', 'min_range'],
+            maxFieldNames: ['sensor_max_range', 'max_range', 'sensor_range']
+        });
+
+        normalized.sensor_min_range = band.min;
+        normalized.sensor_max_range = band.max;
+
+        // Keep the legacy scalar field synchronized with the canonical maximum
+        // range during the migration period so existing range-ring,
+        // configuration, and results code continues to operate until later
+        // phases switch to the canonical min/max fields.
+        normalized.sensor_range = band.max;
+
+        return normalized;
+    }
+
+    function isDistanceInRangeBand(distance, rangeBand) {
+        var parsedDistance = parseRange(distance);
+        if (parsedDistance === null || !rangeBand || !isValidRangeBand(rangeBand.min, rangeBand.max)) {
+            return false;
+        }
+        return parsedDistance >= rangeBand.min && parsedDistance <= rangeBand.max;
+    }
+
+    function formatRange(value) {
+        var parsed = parseRange(value);
+        return parsed === null ? 'Unknown' : parsed.toLocaleString();
+    }
+
+    function formatRangeBand(rangeBand) {
+        if (!rangeBand || !isValidRangeBand(rangeBand.min, rangeBand.max)) {
+            return 'Unknown';
+        }
+        return formatRange(rangeBand.min) + ' - ' + formatRange(rangeBand.max) + ' m';
+    }
+
+    return {
+        DEFAULT_MIN_RANGE: DEFAULT_MIN_RANGE,
+        parseRange: parseRange,
+        getRangeBand: getRangeBand,
+        getWeaponRangeBand: getWeaponRangeBand,
+        getSensorRangeBand: getSensorRangeBand,
+        isValidRangeBand: isValidRangeBand,
+        validateRangeBand: validateRangeBand,
+        normalizeRangeBand: normalizeRangeBand,
+        normalizeWeaponRecord: normalizeWeaponRecord,
+        normalizeSensorRecord: normalizeSensorRecord,
+        isDistanceInRangeBand: isDistanceInRangeBand,
+        formatRange: formatRange,
+        formatRangeBand: formatRangeBand
+    };
+})();

--- a/js/sensors/sensor_storage.js
+++ b/js/sensors/sensor_storage.js
@@ -2,9 +2,16 @@
 var SensorStorage = (function() {
     var sensorData = [];
 
+    function normalizeSensorRecord(item) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.normalizeSensorRecord) {
+            return RangeUtils.normalizeSensorRecord(item);
+        }
+        return Object.assign({}, item);
+    }
+
     function loadInitialData(SENSOR_DATA) {
         sensorData = SENSOR_DATA.map(function(item) {
-            return Object.assign({}, item);
+            return normalizeSensorRecord(item);
         });
     }
 
@@ -17,13 +24,24 @@ var SensorStorage = (function() {
     }
 
     function setSensorData(newSensorData) {
-        sensorData = newSensorData;
+        sensorData = (Array.isArray(newSensorData) ? newSensorData : []).map(function(item) {
+            return normalizeSensorRecord(item);
+        });
+    }
+
+    function getSensorRangeBand(sensor) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.getSensorRangeBand) {
+            return RangeUtils.getSensorRangeBand(sensor);
+        }
+        var maxRange = sensor && sensor.sensor_range !== undefined ? Number(sensor.sensor_range) : null;
+        return { min: 0, max: maxRange, isValid: isFinite(maxRange) && maxRange >= 0 };
     }
 
     return {
         loadInitialData: loadInitialData,
         getSensorData: getSensorData,
         setSensorData: setSensorData,
+        getSensorRangeBand: getSensorRangeBand,
         exportData: exportData
     };
 })();

--- a/js/weapons/weapon_storage.js
+++ b/js/weapons/weapon_storage.js
@@ -2,9 +2,16 @@
 var WeaponStorage = (function() {
     var weaponData = [];
 
+    function normalizeWeaponRecord(item) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.normalizeWeaponRecord) {
+            return RangeUtils.normalizeWeaponRecord(item);
+        }
+        return Object.assign({}, item);
+    }
+
     function loadInitialData(WEAPON_DATA) {
         weaponData = WEAPON_DATA.map(function(item) {
-            return Object.assign({}, item);
+            return normalizeWeaponRecord(item);
         });
     }
 
@@ -17,13 +24,24 @@ var WeaponStorage = (function() {
     }
 
     function setWeaponData(newWeaponData) {
-        weaponData = newWeaponData;
+        weaponData = (Array.isArray(newWeaponData) ? newWeaponData : []).map(function(item) {
+            return normalizeWeaponRecord(item);
+        });
+    }
+
+    function getWeaponRangeBand(weapon) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.getWeaponRangeBand) {
+            return RangeUtils.getWeaponRangeBand(weapon);
+        }
+        var maxRange = weapon && weapon.weapon_range !== undefined ? Number(weapon.weapon_range) : null;
+        return { min: 0, max: maxRange, isValid: isFinite(maxRange) && maxRange >= 0 };
     }
 
     var originalObject = {
         loadInitialData: loadInitialData,
         getWeaponData: getWeaponData,
         setWeaponData: setWeaponData,
+        getWeaponRangeBand: getWeaponRangeBand,
         exportData: exportData
     };
 

--- a/missions.html
+++ b/missions.html
@@ -27,6 +27,7 @@
     <section class="missions-card"><h2>Mission Data Diagnostic Log</h2><pre id="diagnosticLog">Waiting for Missions script initialization...</pre></section>
   </main>
 
+  <script src="js/range_utils.js"></script>
   <script>
     (function () {
       function arr(v) { return Array.isArray(v) ? v : []; }

--- a/missions/js/missions.js
+++ b/missions/js/missions.js
@@ -104,11 +104,17 @@
       return !!weaponNameSet[w.weapon_name];
     });
   }
-  function getWeaponRangeData(weapon) {
+  function getWeaponRangeBandData(weapon) {
     if (!weapon) return null;
-    if (weapon.weapon_range !== undefined) return weapon.weapon_range;
-    if (weapon.max_range !== undefined) return weapon.max_range;
-    return null;
+    if (typeof RangeUtils !== 'undefined' && RangeUtils.getWeaponRangeBand) {
+      return RangeUtils.getWeaponRangeBand(weapon);
+    }
+    var maxRange = weapon.weapon_range !== undefined ? weapon.weapon_range : weapon.max_range;
+    return { min: 0, max: maxRange, isValid: maxRange !== undefined && maxRange !== null };
+  }
+  function getWeaponRangeData(weapon) {
+    var band = getWeaponRangeBandData(weapon);
+    return band ? band.max : null;
   }
   function getWeaponLethalityData(data) { return data.lethality; }
   function getPlatformToPlatformDistanceData(data) { return data.distances; }

--- a/results.html
+++ b/results.html
@@ -56,6 +56,7 @@
     </script>
 
     <script src="js/config/side_config.js"></script>
+    <script src="js/range_utils.js"></script>
     <!-- Custom JavaScript Files -->
     <script src="results/js/globals.js"></script>
     <script src="results/js/utils.js"></script>


### PR DESCRIPTION
### Motivation
- Standardize handling of ranges across weapons, sensors, and UI layers by introducing canonical min/max range bands and migrating legacy scalar fields to a consistent representation.
- Provide validation, formatting, and utility helpers for range-aware features to simplify future range-ring, results, and mission logic.

### Description
- Add `js/range_utils.js` which implements parsing, normalization, validation, formatting, and helpers such as `normalizeWeaponRecord`, `normalizeSensorRecord`, `getWeaponRangeBand`, and `getSensorRangeBand`.
- Wire `range_utils.js` into the app by including the script in `index.html`, `missions.html`, and `results.html` so utilities are available to pages that need range data.
- Update `js/weapons/weapon_storage.js` to normalize weapon records on load/set via `RangeUtils.normalizeWeaponRecord`, expose `getWeaponRangeBand`, and keep legacy `weapon_range` synchronized with the canonical max during migration.
- Update `js/sensors/sensor_storage.js` to normalize sensor records via `RangeUtils.normalizeSensorRecord`, expose `getSensorRangeBand`, and normalize data on `loadInitialData` and `setSensorData`.
- Update `missions/js/missions.js` to use the new band-aware API (`getWeaponRangeBand`) and adapt `getWeaponRangeData` to derive the legacy scalar from the normalized band.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a284bf9d938832a986d713dae6ba65f)