### PR TITLE
Introduce RangeUtils and migrate weapons/sensors to canonical min/max ranges

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,6 +155,7 @@
   <!-------------------------------------------------------------------------->
   <!-- Storage Scripts -->
   <script src="js/platforms/platform_model.js"></script>
+  <script src="js/range_utils.js"></script>
   <script src="js/weapons/weapon_storage.js"></script>
   <script src="js/weapon_lethality/weapon_lethality_storage.js"></script>
   <script src="js/sensors/sensor_storage.js"></script>

--- a/input/sensor_details.js
+++ b/input/sensor_details.js
@@ -2,21 +2,25 @@ var SENSOR_DATA = [
   {
     "sensor_name": "BLUE_SENSOR_1",
     "side": "blue",
-    "sensor_range": 964580
+    "sensor_min_range": 0,
+    "sensor_max_range": 964580
   },
   {
     "sensor_name": "BLUE_SENSOR_2",
     "side": "blue",
-    "sensor_range": 581672
+    "sensor_min_range": 0,
+    "sensor_max_range": 581672
   },
   {
     "sensor_name": "RED_SENSOR_1",
     "side": "red",
-    "sensor_range": 878913
+    "sensor_min_range": 0,
+    "sensor_max_range": 878913
   },
   {
     "sensor_name": "RED_SENSOR_2",
     "side": "red",
-    "sensor_range": 896347
+    "sensor_min_range": 0,
+    "sensor_max_range": 896347
   }
 ];

--- a/input/weapon_details.js
+++ b/input/weapon_details.js
@@ -2,66 +2,79 @@ var WEAPON_DATA = [
   {
     "weapon_name": "BLUE_WEAPON_1",
     "side": "blue",
-    "weapon_range": 760643
+    "weapon_min_range": 0,
+    "weapon_max_range": 760643
   },
   {
     "weapon_name": "BLUE_WEAPON_2",
     "side": "blue",
-    "weapon_range": 819435
+    "weapon_min_range": 0,
+    "weapon_max_range": 819435
   },
   {
     "weapon_name": "BLUE_WEAPON_3",
     "side": "blue",
-    "weapon_range": 940061
+    "weapon_min_range": 0,
+    "weapon_max_range": 940061
   },
   {
     "weapon_name": "BLUE_WEAPON_4",
     "side": "blue",
-    "weapon_range": 538147
+    "weapon_min_range": 0,
+    "weapon_max_range": 538147
   },
   {
     "weapon_name": "BLUE_WEAPON_5",
     "side": "blue",
-    "weapon_range": 578595
+    "weapon_min_range": 0,
+    "weapon_max_range": 578595
   },
   {
     "weapon_name": "RED_WEAPON_1",
     "side": "red",
-    "weapon_range": 544854
+    "weapon_min_range": 0,
+    "weapon_max_range": 544854
   },
   {
     "weapon_name": "RED_WEAPON_2",
     "side": "red",
-    "weapon_range": 743586
+    "weapon_min_range": 0,
+    "weapon_max_range": 743586
   },
   {
     "weapon_name": "RED_WEAPON_3",
     "side": "red",
-    "weapon_range": 858645
+    "weapon_min_range": 0,
+    "weapon_max_range": 858645
   },
   {
     "weapon_name": "RED_WEAPON_4",
     "side": "red",
-    "weapon_range": 546896
+    "weapon_min_range": 0,
+    "weapon_max_range": 546896
   },
   {
     "weapon_name": "RED_WEAPON_5",
     "side": "red",
-    "weapon_range": 976068
+    "weapon_min_range": 0,
+    "weapon_max_range": 976068
   },
   {
     "weapon_name": "RED_WEAPON_6",
     "side": "red",
-    "weapon_range": 619627
+    "weapon_min_range": 0,
+    "weapon_max_range": 619627
   },
   {
     "weapon_name": "RED_WEAPON_7",
     "side": "red",
-    "weapon_range": 526118
+    "weapon_min_range": 0,
+    "weapon_max_range": 526118
   },
   {
     "weapon_name": "RED_WEAPON_8",
     "side": "red",
-    "weapon_range": 726653
+    "weapon_min_range": 0,
+    "weapon_max_range": 726653
   }
 ];

--- a/js/range_utils.js
+++ b/js/range_utils.js
@@ -1,0 +1,234 @@
+// range_utils.js
+// Shared helpers for normalizing, validating, formatting, and evaluating
+// minimum/maximum range bands for weapons, sensors, and range-aware features.
+var RangeUtils = (function() {
+    var DEFAULT_MIN_RANGE = 0;
+
+    function firstDefined(values) {
+        for (var i = 0; i < values.length; i++) {
+            if (values[i] !== undefined && values[i] !== null && values[i] !== '') {
+                return values[i];
+            }
+        }
+        return undefined;
+    }
+
+    function parseRange(value) {
+        if (value === undefined || value === null || value === '') {
+            return null;
+        }
+
+        var parsed = Number(value);
+        return isFinite(parsed) ? parsed : null;
+    }
+
+    function clampMinimum(value, minimum) {
+        return value < minimum ? minimum : value;
+    }
+
+    function getRawRangeValue(record, fieldNames) {
+        if (!record) {
+            return undefined;
+        }
+        return firstDefined(fieldNames.map(function(fieldName) {
+            return record[fieldName];
+        }));
+    }
+
+    function getRangeBand(record, options) {
+        options = options || {};
+        var minFieldNames = options.minFieldNames || ['min_range'];
+        var maxFieldNames = options.maxFieldNames || ['max_range', 'range'];
+        var defaultMinRange = options.defaultMinRange !== undefined ? options.defaultMinRange : DEFAULT_MIN_RANGE;
+
+        var minRange = parseRange(getRawRangeValue(record, minFieldNames));
+        var maxRange = parseRange(getRawRangeValue(record, maxFieldNames));
+
+        if (minRange === null) {
+            minRange = defaultMinRange;
+        }
+
+        return {
+            min: minRange,
+            max: maxRange,
+            isValid: isValidRangeBand(minRange, maxRange)
+        };
+    }
+
+    function getWeaponRangeBand(weapon) {
+        return getRangeBand(weapon, {
+            minFieldNames: ['weapon_min_range', 'min_range'],
+            maxFieldNames: ['weapon_max_range', 'max_range', 'weapon_range']
+        });
+    }
+
+    function getSensorRangeBand(sensor) {
+        return getRangeBand(sensor, {
+            minFieldNames: ['sensor_min_range', 'min_range'],
+            maxFieldNames: ['sensor_max_range', 'max_range', 'sensor_range']
+        });
+    }
+
+    function isValidRangeBand(minRange, maxRange) {
+        return isFinite(minRange) &&
+            isFinite(maxRange) &&
+            minRange >= 0 &&
+            maxRange >= 0 &&
+            minRange <= maxRange;
+    }
+
+    function validateRangeBand(minRange, maxRange) {
+        var errors = [];
+
+        if (!isFinite(minRange)) {
+            errors.push('Minimum range must be a numeric value.');
+        }
+        if (!isFinite(maxRange)) {
+            errors.push('Maximum range must be a numeric value.');
+        }
+        if (isFinite(minRange) && minRange < 0) {
+            errors.push('Minimum range cannot be negative.');
+        }
+        if (isFinite(maxRange) && maxRange < 0) {
+            errors.push('Maximum range cannot be negative.');
+        }
+        if (isFinite(minRange) && isFinite(maxRange) && minRange > maxRange) {
+            errors.push('Minimum range cannot be greater than maximum range.');
+        }
+
+        return {
+            isValid: errors.length === 0,
+            errors: errors
+        };
+    }
+
+    function normalizeRangeBand(record, options) {
+        options = options || {};
+        var band = getRangeBand(record, options);
+        var minRange = parseRange(band.min);
+        var maxRange = parseRange(band.max);
+
+        if (minRange === null) {
+            minRange = options.defaultMinRange !== undefined ? options.defaultMinRange : DEFAULT_MIN_RANGE;
+        }
+
+        if (options.clampToZero !== false) {
+            minRange = clampMinimum(minRange, 0);
+            if (maxRange !== null) {
+                maxRange = clampMinimum(maxRange, 0);
+            }
+        }
+
+        if (maxRange === null) {
+            maxRange = minRange;
+        }
+
+        return {
+            min: minRange,
+            max: maxRange,
+            isValid: isValidRangeBand(minRange, maxRange),
+            validation: validateRangeBand(minRange, maxRange)
+        };
+    }
+
+    function normalizeWeaponRecord(weapon) {
+        var normalized = Object.assign({}, weapon || {});
+        var band = normalizeRangeBand(normalized, {
+            minFieldNames: ['weapon_min_range', 'min_range'],
+            maxFieldNames: ['weapon_max_range', 'max_range', 'weapon_range']
+        });
+
+        normalized.weapon_min_range = band.min;
+        normalized.weapon_max_range = band.max;
+
+        // Keep the legacy scalar field synchronized with the canonical maximum
+        // range during the migration period so existing range-ring,
+        // configuration, and results code continues to operate until later
+        // phases switch to the canonical min/max fields.
+        normalized.weapon_range = band.max;
+
+        return normalized;
+    }
+
+    function normalizeSensorRecord(sensor) {
+        var normalized = Object.assign({}, sensor || {});
+        var band = normalizeRangeBand(normalized, {
+            minFieldNames: ['sensor_min_range', 'min_range'],
+            maxFieldNames: ['sensor_max_range', 'max_range', 'sensor_range']
+        });
+
+        normalized.sensor_min_range = band.min;
+        normalized.sensor_max_range = band.max;
+
+        // Keep the legacy scalar field synchronized with the canonical maximum
+        // range during the migration period so existing range-ring,
+        // configuration, and results code continues to operate until later
+        // phases switch to the canonical min/max fields.
+        normalized.sensor_range = band.max;
+
+        return normalized;
+    }
+
+
+    function removeFields(record, fieldNames) {
+        var output = Object.assign({}, record || {});
+        fieldNames.forEach(function(fieldName) {
+            delete output[fieldName];
+        });
+        return output;
+    }
+
+    function getCanonicalWeaponRecord(weapon) {
+        var normalized = normalizeWeaponRecord(weapon);
+        var canonical = removeFields(normalized, ['weapon_range', 'min_range', 'max_range', 'index']);
+        canonical.weapon_min_range = normalized.weapon_min_range;
+        canonical.weapon_max_range = normalized.weapon_max_range;
+        return canonical;
+    }
+
+    function getCanonicalSensorRecord(sensor) {
+        var normalized = normalizeSensorRecord(sensor);
+        var canonical = removeFields(normalized, ['sensor_range', 'min_range', 'max_range', 'index']);
+        canonical.sensor_min_range = normalized.sensor_min_range;
+        canonical.sensor_max_range = normalized.sensor_max_range;
+        return canonical;
+    }
+
+    function isDistanceInRangeBand(distance, rangeBand) {
+        var parsedDistance = parseRange(distance);
+        if (parsedDistance === null || !rangeBand || !isValidRangeBand(rangeBand.min, rangeBand.max)) {
+            return false;
+        }
+        return parsedDistance >= rangeBand.min && parsedDistance <= rangeBand.max;
+    }
+
+    function formatRange(value) {
+        var parsed = parseRange(value);
+        return parsed === null ? 'Unknown' : parsed.toLocaleString();
+    }
+
+    function formatRangeBand(rangeBand) {
+        if (!rangeBand || !isValidRangeBand(rangeBand.min, rangeBand.max)) {
+            return 'Unknown';
+        }
+        return formatRange(rangeBand.min) + ' - ' + formatRange(rangeBand.max) + ' m';
+    }
+
+    return {
+        DEFAULT_MIN_RANGE: DEFAULT_MIN_RANGE,
+        parseRange: parseRange,
+        getRangeBand: getRangeBand,
+        getWeaponRangeBand: getWeaponRangeBand,
+        getSensorRangeBand: getSensorRangeBand,
+        isValidRangeBand: isValidRangeBand,
+        validateRangeBand: validateRangeBand,
+        normalizeRangeBand: normalizeRangeBand,
+        normalizeWeaponRecord: normalizeWeaponRecord,
+        normalizeSensorRecord: normalizeSensorRecord,
+        getCanonicalWeaponRecord: getCanonicalWeaponRecord,
+        getCanonicalSensorRecord: getCanonicalSensorRecord,
+        isDistanceInRangeBand: isDistanceInRangeBand,
+        formatRange: formatRange,
+        formatRangeBand: formatRangeBand
+    };
+})();

--- a/js/sensors/sensor_storage.js
+++ b/js/sensors/sensor_storage.js
@@ -2,9 +2,16 @@
 var SensorStorage = (function() {
     var sensorData = [];
 
+    function normalizeSensorRecord(item) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.normalizeSensorRecord) {
+            return RangeUtils.normalizeSensorRecord(item);
+        }
+        return Object.assign({}, item);
+    }
+
     function loadInitialData(SENSOR_DATA) {
         sensorData = SENSOR_DATA.map(function(item) {
-            return Object.assign({}, item);
+            return normalizeSensorRecord(item);
         });
     }
 
@@ -12,18 +19,39 @@ var SensorStorage = (function() {
         return sensorData;
     }
 
+    function getCanonicalSensorRecord(item) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.getCanonicalSensorRecord) {
+            return RangeUtils.getCanonicalSensorRecord(item);
+        }
+        return normalizeSensorRecord(item);
+    }
+
     function exportData() {
-        return JSON.stringify(sensorData, null, 2);
+        var canonicalSensorData = sensorData.map(function(item) {
+            return getCanonicalSensorRecord(item);
+        });
+        return JSON.stringify(canonicalSensorData, null, 2);
     }
 
     function setSensorData(newSensorData) {
-        sensorData = newSensorData;
+        sensorData = (Array.isArray(newSensorData) ? newSensorData : []).map(function(item) {
+            return normalizeSensorRecord(item);
+        });
+    }
+
+    function getSensorRangeBand(sensor) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.getSensorRangeBand) {
+            return RangeUtils.getSensorRangeBand(sensor);
+        }
+        var maxRange = sensor && sensor.sensor_range !== undefined ? Number(sensor.sensor_range) : null;
+        return { min: 0, max: maxRange, isValid: isFinite(maxRange) && maxRange >= 0 };
     }
 
     return {
         loadInitialData: loadInitialData,
         getSensorData: getSensorData,
         setSensorData: setSensorData,
+        getSensorRangeBand: getSensorRangeBand,
         exportData: exportData
     };
 })();

--- a/js/weapons/weapon_storage.js
+++ b/js/weapons/weapon_storage.js
@@ -2,9 +2,16 @@
 var WeaponStorage = (function() {
     var weaponData = [];
 
+    function normalizeWeaponRecord(item) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.normalizeWeaponRecord) {
+            return RangeUtils.normalizeWeaponRecord(item);
+        }
+        return Object.assign({}, item);
+    }
+
     function loadInitialData(WEAPON_DATA) {
         weaponData = WEAPON_DATA.map(function(item) {
-            return Object.assign({}, item);
+            return normalizeWeaponRecord(item);
         });
     }
 
@@ -12,18 +19,39 @@ var WeaponStorage = (function() {
         return weaponData;
     }
 
+    function getCanonicalWeaponRecord(item) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.getCanonicalWeaponRecord) {
+            return RangeUtils.getCanonicalWeaponRecord(item);
+        }
+        return normalizeWeaponRecord(item);
+    }
+
     function exportData() {
-        return JSON.stringify(weaponData, null, 2);
+        var canonicalWeaponData = weaponData.map(function(item) {
+            return getCanonicalWeaponRecord(item);
+        });
+        return JSON.stringify(canonicalWeaponData, null, 2);
     }
 
     function setWeaponData(newWeaponData) {
-        weaponData = newWeaponData;
+        weaponData = (Array.isArray(newWeaponData) ? newWeaponData : []).map(function(item) {
+            return normalizeWeaponRecord(item);
+        });
+    }
+
+    function getWeaponRangeBand(weapon) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.getWeaponRangeBand) {
+            return RangeUtils.getWeaponRangeBand(weapon);
+        }
+        var maxRange = weapon && weapon.weapon_range !== undefined ? Number(weapon.weapon_range) : null;
+        return { min: 0, max: maxRange, isValid: isFinite(maxRange) && maxRange >= 0 };
     }
 
     var originalObject = {
         loadInitialData: loadInitialData,
         getWeaponData: getWeaponData,
         setWeaponData: setWeaponData,
+        getWeaponRangeBand: getWeaponRangeBand,
         exportData: exportData
     };
 

--- a/missions.html
+++ b/missions.html
@@ -27,6 +27,7 @@
     <section class="missions-card"><h2>Mission Data Diagnostic Log</h2><pre id="diagnosticLog">Waiting for Missions script initialization...</pre></section>
   </main>
 
+  <script src="js/range_utils.js"></script>
   <script>
     (function () {
       function arr(v) { return Array.isArray(v) ? v : []; }

--- a/missions/js/missions.js
+++ b/missions/js/missions.js
@@ -104,11 +104,17 @@
       return !!weaponNameSet[w.weapon_name];
     });
   }
-  function getWeaponRangeData(weapon) {
+  function getWeaponRangeBandData(weapon) {
     if (!weapon) return null;
-    if (weapon.weapon_range !== undefined) return weapon.weapon_range;
-    if (weapon.max_range !== undefined) return weapon.max_range;
-    return null;
+    if (typeof RangeUtils !== 'undefined' && RangeUtils.getWeaponRangeBand) {
+      return RangeUtils.getWeaponRangeBand(weapon);
+    }
+    var maxRange = weapon.weapon_range !== undefined ? weapon.weapon_range : weapon.max_range;
+    return { min: 0, max: maxRange, isValid: maxRange !== undefined && maxRange !== null };
+  }
+  function getWeaponRangeData(weapon) {
+    var band = getWeaponRangeBandData(weapon);
+    return band ? band.max : null;
   }
   function getWeaponLethalityData(data) { return data.lethality; }
   function getPlatformToPlatformDistanceData(data) { return data.distances; }

--- a/results.html
+++ b/results.html
@@ -56,6 +56,7 @@
     </script>
 
     <script src="js/config/side_config.js"></script>
+    <script src="js/range_utils.js"></script>
     <!-- Custom JavaScript Files -->
     <script src="results/js/globals.js"></script>
     <script src="results/js/utils.js"></script>


### PR DESCRIPTION
### Motivation
- Provide a canonical representation and helpers for minimum/maximum range bands for weapons and sensors to support range-aware features and a staged migration away from legacy scalar `*_range` fields.

### Description
- Add `js/range_utils.js` implementing `RangeUtils` with parsing, validation, normalization, canonicalization, formatting, and utility functions for weapon and sensor range bands.
- Migrate input data to explicit min/max fields by updating `input/weapon_details.js` and `input/sensor_details.js` to include `*_min_range` and `*_max_range` while retaining legacy semantics during normalization.
- Update storage modules `js/weapons/weapon_storage.js` and `js/sensors/sensor_storage.js` to normalize records via `RangeUtils`, provide `get*RangeBand` helpers, and export canonical records without legacy transient fields.
- Wire the new `range_utils.js` into the app by adding `<script src="js/range_utils.js"></script>` to `index.html`, `missions.html`, and `results.html`, and modify `missions/js/missions.js` to consume range bands via `RangeUtils` while preserving the previous `getWeaponRangeData` API.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a284bf9d938832a986d713dae6ba65f)