### PR TITLE
Phase 2: Migrate weapon/sensor seeds to canonical min/max ranges and emit canonical exports

### DIFF
--- a/input/sensor_details.js
+++ b/input/sensor_details.js
@@ -2,21 +2,25 @@ var SENSOR_DATA = [
   {
     "sensor_name": "BLUE_SENSOR_1",
     "side": "blue",
-    "sensor_range": 964580
+    "sensor_min_range": 0,
+    "sensor_max_range": 964580
   },
   {
     "sensor_name": "BLUE_SENSOR_2",
     "side": "blue",
-    "sensor_range": 581672
+    "sensor_min_range": 0,
+    "sensor_max_range": 581672
   },
   {
     "sensor_name": "RED_SENSOR_1",
     "side": "red",
-    "sensor_range": 878913
+    "sensor_min_range": 0,
+    "sensor_max_range": 878913
   },
   {
     "sensor_name": "RED_SENSOR_2",
     "side": "red",
-    "sensor_range": 896347
+    "sensor_min_range": 0,
+    "sensor_max_range": 896347
   }
 ];

--- a/input/weapon_details.js
+++ b/input/weapon_details.js
@@ -2,66 +2,79 @@ var WEAPON_DATA = [
   {
     "weapon_name": "BLUE_WEAPON_1",
     "side": "blue",
-    "weapon_range": 760643
+    "weapon_min_range": 0,
+    "weapon_max_range": 760643
   },
   {
     "weapon_name": "BLUE_WEAPON_2",
     "side": "blue",
-    "weapon_range": 819435
+    "weapon_min_range": 0,
+    "weapon_max_range": 819435
   },
   {
     "weapon_name": "BLUE_WEAPON_3",
     "side": "blue",
-    "weapon_range": 940061
+    "weapon_min_range": 0,
+    "weapon_max_range": 940061
   },
   {
     "weapon_name": "BLUE_WEAPON_4",
     "side": "blue",
-    "weapon_range": 538147
+    "weapon_min_range": 0,
+    "weapon_max_range": 538147
   },
   {
     "weapon_name": "BLUE_WEAPON_5",
     "side": "blue",
-    "weapon_range": 578595
+    "weapon_min_range": 0,
+    "weapon_max_range": 578595
   },
   {
     "weapon_name": "RED_WEAPON_1",
     "side": "red",
-    "weapon_range": 544854
+    "weapon_min_range": 0,
+    "weapon_max_range": 544854
   },
   {
     "weapon_name": "RED_WEAPON_2",
     "side": "red",
-    "weapon_range": 743586
+    "weapon_min_range": 0,
+    "weapon_max_range": 743586
   },
   {
     "weapon_name": "RED_WEAPON_3",
     "side": "red",
-    "weapon_range": 858645
+    "weapon_min_range": 0,
+    "weapon_max_range": 858645
   },
   {
     "weapon_name": "RED_WEAPON_4",
     "side": "red",
-    "weapon_range": 546896
+    "weapon_min_range": 0,
+    "weapon_max_range": 546896
   },
   {
     "weapon_name": "RED_WEAPON_5",
     "side": "red",
-    "weapon_range": 976068
+    "weapon_min_range": 0,
+    "weapon_max_range": 976068
   },
   {
     "weapon_name": "RED_WEAPON_6",
     "side": "red",
-    "weapon_range": 619627
+    "weapon_min_range": 0,
+    "weapon_max_range": 619627
   },
   {
     "weapon_name": "RED_WEAPON_7",
     "side": "red",
-    "weapon_range": 526118
+    "weapon_min_range": 0,
+    "weapon_max_range": 526118
   },
   {
     "weapon_name": "RED_WEAPON_8",
     "side": "red",
-    "weapon_range": 726653
+    "weapon_min_range": 0,
+    "weapon_max_range": 726653
   }
 ];

--- a/js/range_utils.js
+++ b/js/range_utils.js
@@ -169,6 +169,70 @@ var RangeUtils = (function() {
         return normalized;
     }
 
+
+
+    function getCanonicalWeaponRecord(weapon) {
+        var normalized = normalizeWeaponRecord(weapon);
+        var canonical = {};
+
+        if (normalized.weapon_name !== undefined) {
+            canonical.weapon_name = normalized.weapon_name;
+        }
+        if (normalized.side !== undefined) {
+            canonical.side = normalized.side;
+        }
+
+        Object.keys(normalized).forEach(function(key) {
+            if (key === 'weapon_name' ||
+                key === 'side' ||
+                key === 'weapon_range' ||
+                key === 'weapon_min_range' ||
+                key === 'weapon_max_range' ||
+                key === 'min_range' ||
+                key === 'max_range' ||
+                key === 'index') {
+                return;
+            }
+            canonical[key] = normalized[key];
+        });
+
+        canonical.weapon_min_range = normalized.weapon_min_range;
+        canonical.weapon_max_range = normalized.weapon_max_range;
+
+        return canonical;
+    }
+
+    function getCanonicalSensorRecord(sensor) {
+        var normalized = normalizeSensorRecord(sensor);
+        var canonical = {};
+
+        if (normalized.sensor_name !== undefined) {
+            canonical.sensor_name = normalized.sensor_name;
+        }
+        if (normalized.side !== undefined) {
+            canonical.side = normalized.side;
+        }
+
+        Object.keys(normalized).forEach(function(key) {
+            if (key === 'sensor_name' ||
+                key === 'side' ||
+                key === 'sensor_range' ||
+                key === 'sensor_min_range' ||
+                key === 'sensor_max_range' ||
+                key === 'min_range' ||
+                key === 'max_range' ||
+                key === 'index') {
+                return;
+            }
+            canonical[key] = normalized[key];
+        });
+
+        canonical.sensor_min_range = normalized.sensor_min_range;
+        canonical.sensor_max_range = normalized.sensor_max_range;
+
+        return canonical;
+    }
+
     function isDistanceInRangeBand(distance, rangeBand) {
         var parsedDistance = parseRange(distance);
         if (parsedDistance === null || !rangeBand || !isValidRangeBand(rangeBand.min, rangeBand.max)) {
@@ -200,6 +264,8 @@ var RangeUtils = (function() {
         normalizeRangeBand: normalizeRangeBand,
         normalizeWeaponRecord: normalizeWeaponRecord,
         normalizeSensorRecord: normalizeSensorRecord,
+        getCanonicalWeaponRecord: getCanonicalWeaponRecord,
+        getCanonicalSensorRecord: getCanonicalSensorRecord,
         isDistanceInRangeBand: isDistanceInRangeBand,
         formatRange: formatRange,
         formatRangeBand: formatRangeBand

--- a/js/sensors/sensor_storage.js
+++ b/js/sensors/sensor_storage.js
@@ -19,8 +19,24 @@ var SensorStorage = (function() {
         return sensorData;
     }
 
+    function getCanonicalSensorRecord(item) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.getCanonicalSensorRecord) {
+            return RangeUtils.getCanonicalSensorRecord(item);
+        }
+        var normalized = normalizeSensorRecord(item);
+        var canonical = Object.assign({}, normalized);
+        delete canonical.sensor_range;
+        delete canonical.min_range;
+        delete canonical.max_range;
+        delete canonical.index;
+        return canonical;
+    }
+
     function exportData() {
-        return JSON.stringify(sensorData, null, 2);
+        var canonicalSensorData = sensorData.map(function(item) {
+            return getCanonicalSensorRecord(item);
+        });
+        return JSON.stringify(canonicalSensorData, null, 2);
     }
 
     function setSensorData(newSensorData) {

--- a/js/weapons/weapon_storage.js
+++ b/js/weapons/weapon_storage.js
@@ -19,8 +19,24 @@ var WeaponStorage = (function() {
         return weaponData;
     }
 
+    function getCanonicalWeaponRecord(item) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.getCanonicalWeaponRecord) {
+            return RangeUtils.getCanonicalWeaponRecord(item);
+        }
+        var normalized = normalizeWeaponRecord(item);
+        var canonical = Object.assign({}, normalized);
+        delete canonical.weapon_range;
+        delete canonical.min_range;
+        delete canonical.max_range;
+        delete canonical.index;
+        return canonical;
+    }
+
     function exportData() {
-        return JSON.stringify(weaponData, null, 2);
+        var canonicalWeaponData = weaponData.map(function(item) {
+            return getCanonicalWeaponRecord(item);
+        });
+        return JSON.stringify(canonicalWeaponData, null, 2);
     }
 
     function setWeaponData(newWeaponData) {


### PR DESCRIPTION
### Motivation
- Make exported laydowns canonical by moving from legacy scalar `weapon_range`/`sensor_range` to explicit `weapon_min_range`/`weapon_max_range` and `sensor_min_range`/`sensor_max_range` fields while preserving backward-compatible behavior during migration. 
- Ensure storage export does not leak transient UI or legacy alias fields and that downstream consumers receive a stable canonical schema for Phase 3 work. 

### Description
- Converted seed input files to the canonical shape by replacing legacy scalar fields with min/max fields and setting `*_min_range` to `0` and `*_max_range` to the previous scalar values in `input/weapon_details.js` and `input/sensor_details.js`.
- Added canonicalization helpers to `js/range_utils.js`: `getCanonicalWeaponRecord` and `getCanonicalSensorRecord`, and exposed them via `RangeUtils` for reuse by storage/export code. 
- Updated `js/weapons/weapon_storage.js` and `js/sensors/sensor_storage.js` to export canonical records by mapping in-memory normalized items through the new canonical helpers and to strip legacy scalar aliases and UI-only `index` before serialization. 
- Kept normalization on load/set so legacy inputs still normalize to min/max in-memory via existing `normalizeWeaponRecord`/`normalizeSensorRecord`, while exports now emit only the canonical min/max fields.

### Testing
- Ran static syntax checks with `node --check js/range_utils.js && node --check js/weapons/weapon_storage.js && node --check js/sensors/sensor_storage.js && node --check input/weapon_details.js && node --check input/sensor_details.js`, which succeeded. 
- Executed a Node VM smoke test that initialized `WeaponStorage`/`SensorStorage` with both migrated and legacy inputs and verified exported JSON contains `*_min_range` and `*_max_range` and omits legacy `weapon_range`/`sensor_range` and UI `index`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a295a7e2c28832aad655c91a8f80487)