### PR TITLE
Migrate weapon and sensor range exports to canonical min/max schema

### DIFF
--- a/input/sensor_details.js
+++ b/input/sensor_details.js
@@ -2,21 +2,25 @@ var SENSOR_DATA = [
   {
     "sensor_name": "BLUE_SENSOR_1",
     "side": "blue",
-    "sensor_range": 964580
+    "sensor_min_range": 0,
+    "sensor_max_range": 964580
   },
   {
     "sensor_name": "BLUE_SENSOR_2",
     "side": "blue",
-    "sensor_range": 581672
+    "sensor_min_range": 0,
+    "sensor_max_range": 581672
   },
   {
     "sensor_name": "RED_SENSOR_1",
     "side": "red",
-    "sensor_range": 878913
+    "sensor_min_range": 0,
+    "sensor_max_range": 878913
   },
   {
     "sensor_name": "RED_SENSOR_2",
     "side": "red",
-    "sensor_range": 896347
+    "sensor_min_range": 0,
+    "sensor_max_range": 896347
   }
 ];

--- a/input/weapon_details.js
+++ b/input/weapon_details.js
@@ -2,66 +2,79 @@ var WEAPON_DATA = [
   {
     "weapon_name": "BLUE_WEAPON_1",
     "side": "blue",
-    "weapon_range": 760643
+    "weapon_min_range": 0,
+    "weapon_max_range": 760643
   },
   {
     "weapon_name": "BLUE_WEAPON_2",
     "side": "blue",
-    "weapon_range": 819435
+    "weapon_min_range": 0,
+    "weapon_max_range": 819435
   },
   {
     "weapon_name": "BLUE_WEAPON_3",
     "side": "blue",
-    "weapon_range": 940061
+    "weapon_min_range": 0,
+    "weapon_max_range": 940061
   },
   {
     "weapon_name": "BLUE_WEAPON_4",
     "side": "blue",
-    "weapon_range": 538147
+    "weapon_min_range": 0,
+    "weapon_max_range": 538147
   },
   {
     "weapon_name": "BLUE_WEAPON_5",
     "side": "blue",
-    "weapon_range": 578595
+    "weapon_min_range": 0,
+    "weapon_max_range": 578595
   },
   {
     "weapon_name": "RED_WEAPON_1",
     "side": "red",
-    "weapon_range": 544854
+    "weapon_min_range": 0,
+    "weapon_max_range": 544854
   },
   {
     "weapon_name": "RED_WEAPON_2",
     "side": "red",
-    "weapon_range": 743586
+    "weapon_min_range": 0,
+    "weapon_max_range": 743586
   },
   {
     "weapon_name": "RED_WEAPON_3",
     "side": "red",
-    "weapon_range": 858645
+    "weapon_min_range": 0,
+    "weapon_max_range": 858645
   },
   {
     "weapon_name": "RED_WEAPON_4",
     "side": "red",
-    "weapon_range": 546896
+    "weapon_min_range": 0,
+    "weapon_max_range": 546896
   },
   {
     "weapon_name": "RED_WEAPON_5",
     "side": "red",
-    "weapon_range": 976068
+    "weapon_min_range": 0,
+    "weapon_max_range": 976068
   },
   {
     "weapon_name": "RED_WEAPON_6",
     "side": "red",
-    "weapon_range": 619627
+    "weapon_min_range": 0,
+    "weapon_max_range": 619627
   },
   {
     "weapon_name": "RED_WEAPON_7",
     "side": "red",
-    "weapon_range": 526118
+    "weapon_min_range": 0,
+    "weapon_max_range": 526118
   },
   {
     "weapon_name": "RED_WEAPON_8",
     "side": "red",
-    "weapon_range": 726653
+    "weapon_min_range": 0,
+    "weapon_max_range": 726653
   }
 ];

--- a/js/range_utils.js
+++ b/js/range_utils.js
@@ -169,6 +169,24 @@ var RangeUtils = (function() {
         return normalized;
     }
 
+    function removeMigrationOnlyFields(record, fieldNames) {
+        var canonical = Object.assign({}, record || {});
+        fieldNames.forEach(function(fieldName) {
+            delete canonical[fieldName];
+        });
+        return canonical;
+    }
+
+    function toCanonicalWeaponRecord(weapon) {
+        var normalized = normalizeWeaponRecord(weapon);
+        return removeMigrationOnlyFields(normalized, ['weapon_range', 'min_range', 'max_range', 'index']);
+    }
+
+    function toCanonicalSensorRecord(sensor) {
+        var normalized = normalizeSensorRecord(sensor);
+        return removeMigrationOnlyFields(normalized, ['sensor_range', 'min_range', 'max_range', 'index']);
+    }
+
     function isDistanceInRangeBand(distance, rangeBand) {
         var parsedDistance = parseRange(distance);
         if (parsedDistance === null || !rangeBand || !isValidRangeBand(rangeBand.min, rangeBand.max)) {
@@ -200,6 +218,8 @@ var RangeUtils = (function() {
         normalizeRangeBand: normalizeRangeBand,
         normalizeWeaponRecord: normalizeWeaponRecord,
         normalizeSensorRecord: normalizeSensorRecord,
+        toCanonicalWeaponRecord: toCanonicalWeaponRecord,
+        toCanonicalSensorRecord: toCanonicalSensorRecord,
         isDistanceInRangeBand: isDistanceInRangeBand,
         formatRange: formatRange,
         formatRangeBand: formatRangeBand

--- a/js/sensors/sensor_storage.js
+++ b/js/sensors/sensor_storage.js
@@ -19,8 +19,23 @@ var SensorStorage = (function() {
         return sensorData;
     }
 
+    function toCanonicalSensorRecord(item) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.toCanonicalSensorRecord) {
+            return RangeUtils.toCanonicalSensorRecord(item);
+        }
+
+        var normalized = normalizeSensorRecord(item);
+        delete normalized.sensor_range;
+        delete normalized.min_range;
+        delete normalized.max_range;
+        delete normalized.index;
+        return normalized;
+    }
+
     function exportData() {
-        return JSON.stringify(sensorData, null, 2);
+        return JSON.stringify(sensorData.map(function(item) {
+            return toCanonicalSensorRecord(item);
+        }), null, 2);
     }
 
     function setSensorData(newSensorData) {
@@ -33,8 +48,14 @@ var SensorStorage = (function() {
         if (typeof RangeUtils !== 'undefined' && RangeUtils.getSensorRangeBand) {
             return RangeUtils.getSensorRangeBand(sensor);
         }
-        var maxRange = sensor && sensor.sensor_range !== undefined ? Number(sensor.sensor_range) : null;
-        return { min: 0, max: maxRange, isValid: isFinite(maxRange) && maxRange >= 0 };
+        var minRange = sensor && sensor.sensor_min_range !== undefined ? Number(sensor.sensor_min_range) : 0;
+        var maxRange = sensor && sensor.sensor_max_range !== undefined ? Number(sensor.sensor_max_range) :
+            (sensor && sensor.sensor_range !== undefined ? Number(sensor.sensor_range) : null);
+        return {
+            min: minRange,
+            max: maxRange,
+            isValid: isFinite(minRange) && isFinite(maxRange) && minRange >= 0 && maxRange >= 0 && minRange <= maxRange
+        };
     }
 
     return {

--- a/js/weapons/weapon_storage.js
+++ b/js/weapons/weapon_storage.js
@@ -19,8 +19,23 @@ var WeaponStorage = (function() {
         return weaponData;
     }
 
+    function toCanonicalWeaponRecord(item) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.toCanonicalWeaponRecord) {
+            return RangeUtils.toCanonicalWeaponRecord(item);
+        }
+
+        var normalized = normalizeWeaponRecord(item);
+        delete normalized.weapon_range;
+        delete normalized.min_range;
+        delete normalized.max_range;
+        delete normalized.index;
+        return normalized;
+    }
+
     function exportData() {
-        return JSON.stringify(weaponData, null, 2);
+        return JSON.stringify(weaponData.map(function(item) {
+            return toCanonicalWeaponRecord(item);
+        }), null, 2);
     }
 
     function setWeaponData(newWeaponData) {
@@ -33,8 +48,14 @@ var WeaponStorage = (function() {
         if (typeof RangeUtils !== 'undefined' && RangeUtils.getWeaponRangeBand) {
             return RangeUtils.getWeaponRangeBand(weapon);
         }
-        var maxRange = weapon && weapon.weapon_range !== undefined ? Number(weapon.weapon_range) : null;
-        return { min: 0, max: maxRange, isValid: isFinite(maxRange) && maxRange >= 0 };
+        var minRange = weapon && weapon.weapon_min_range !== undefined ? Number(weapon.weapon_min_range) : 0;
+        var maxRange = weapon && weapon.weapon_max_range !== undefined ? Number(weapon.weapon_max_range) :
+            (weapon && weapon.weapon_range !== undefined ? Number(weapon.weapon_range) : null);
+        return {
+            min: minRange,
+            max: maxRange,
+            isValid: isFinite(minRange) && isFinite(maxRange) && minRange >= 0 && maxRange >= 0 && minRange <= maxRange
+        };
     }
 
     var originalObject = {


### PR DESCRIPTION
### Motivation
- Implement Phase 2 (input and export migration) so seed data and laydown exports use canonical min/max range fields while preserving runtime compatibility with legacy scalar fields.
- Provide a single canonicalization path so consumers can migrate off ad-hoc fallbacks and exported laydowns no longer include migration-only aliases or UI-only fields.

### Description
- Updated seed data in `input/weapon_details.js` and `input/sensor_details.js` to use `weapon_min_range`/`weapon_max_range` and `sensor_min_range`/`sensor_max_range` with `0` as the default minimum and the legacy scalar preserved as the maximum. 
- Added export/canonicalization helpers in `js/range_utils.js`: `removeMigrationOnlyFields`, `toCanonicalWeaponRecord`, and `toCanonicalSensorRecord` and kept the existing normalization helpers (`normalizeWeaponRecord`/`normalizeSensorRecord`).
- Changed `js/weapons/weapon_storage.js` and `js/sensors/sensor_storage.js` to export canonical records by stripping migration-only fields (legacy `weapon_range`/`sensor_range`, generic `min_range`/`max_range` aliases, and `index`) while keeping in-memory normalized records and a legacy scalar synchronized for compatibility.
- Hardened fallback accessors `getWeaponRangeBand` and `getSensorRangeBand` to prefer canonical `*_min_range`/`*_max_range` and to fall back to legacy scalar `weapon_range`/`sensor_range` if present.

### Testing
- Ran syntax checks with `node --check` against updated files and they succeeded. 
- Executed a Node VM smoke test that loads `RangeUtils`, `WeaponStorage`, and `SensorStorage`, verifies normalization of legacy and canonical inputs, and asserts exported JSON no longer contains migration-only fields; the test passed. 
- Verified seed files contain no legacy scalar fields with a search (`rg`) and confirmed success. 
- Ran `git diff --check` to ensure no whitespace/conflict issues and it returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a295a7e2c28832aad655c91a8f80487)