### PR TITLE
Implement min/max range inputs and UI for weapons and sensors (Phase 3)

### DIFF
--- a/dialog_init.js
+++ b/dialog_init.js
@@ -21,7 +21,7 @@ $(function () {
       autoOpen: false,
       draggable: true,
       resizable: true,
-      width: 700,
+      width: 850,
       position: { 
         my: "center",
         at: "center+0+150",
@@ -37,7 +37,7 @@ $(function () {
       autoOpen: false,
       draggable: true,
       resizable: true,
-      width: 700,
+      width: 850,
       position: { 
         my: "center",
         at: "center+0+150",

--- a/js/platforms/plat_config.js
+++ b/js/platforms/plat_config.js
@@ -51,6 +51,50 @@ var PlatformConfig = (function() {
         return optionsHtml;
     }
 
+    function formatRangeBand(rangeBand) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.formatRangeBand) {
+            return RangeUtils.formatRangeBand(rangeBand);
+        }
+        if (!rangeBand || rangeBand.min === undefined || rangeBand.max === undefined) {
+            return 'N/A';
+        }
+        return rangeBand.min + ' - ' + rangeBand.max + ' m';
+    }
+
+    function getWeaponRangeBand(weapon) {
+        if (WeaponStorage.getWeaponRangeBand) {
+            return WeaponStorage.getWeaponRangeBand(weapon);
+        }
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.getWeaponRangeBand) {
+            return RangeUtils.getWeaponRangeBand(weapon);
+        }
+        return {
+            min: weapon && weapon.weapon_min_range !== undefined ? Number(weapon.weapon_min_range) : 0,
+            max: weapon && weapon.weapon_max_range !== undefined ? Number(weapon.weapon_max_range) : Number(weapon && weapon.weapon_range)
+        };
+    }
+
+    function getSensorRangeBand(sensor) {
+        if (SensorStorage.getSensorRangeBand) {
+            return SensorStorage.getSensorRangeBand(sensor);
+        }
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.getSensorRangeBand) {
+            return RangeUtils.getSensorRangeBand(sensor);
+        }
+        return {
+            min: sensor && sensor.sensor_min_range !== undefined ? Number(sensor.sensor_min_range) : 0,
+            max: sensor && sensor.sensor_max_range !== undefined ? Number(sensor.sensor_max_range) : Number(sensor && sensor.sensor_range)
+        };
+    }
+
+    function formatWeaponRangeBand(weapon) {
+        return weapon ? formatRangeBand(getWeaponRangeBand(weapon)) : 'N/A';
+    }
+
+    function formatSensorRangeBand(sensor) {
+        return sensor ? formatRangeBand(getSensorRangeBand(sensor)) : 'N/A';
+    }
+
     // Function to create platform info dialog with inputs
     function createPlatformDialog(platform) {
         var sideOptions = buildSideOptions(platform && platform.side);
@@ -102,7 +146,7 @@ var PlatformConfig = (function() {
                 color: white;
                 border: none;
             }
-    
+
             /* Optional: Responsive Adjustments */
             @media (max-width: 768px) {
                 .main-table, .basic-info-table {
@@ -114,7 +158,7 @@ var PlatformConfig = (function() {
                 }
             }
         </style>
-    
+
         <!-- Main Configuration Table -->
         <table class="main-table">
             <tr>
@@ -127,7 +171,7 @@ var PlatformConfig = (function() {
                             <td><label for="platformNameInput"><strong>Name:</strong></label></td>
                             <td><input type="text" id="platformNameInput" value="${platform.platform_name}" class="full-width" maxlength="32"></td>
                         </tr>
-                        
+
                         <!-- Row 2: Group -->
                         <tr>
                             <td><label for="platformGroupInput"><strong>Group:</strong></label></td>
@@ -155,7 +199,7 @@ var PlatformConfig = (function() {
                                 </select>
                             </td>
                         </tr>
-                        
+
                         <!-- Row 6: Latitude -->
                         <tr>
                             <td><label for="platformLatitudeInput"><strong>Latitude:</strong></label></td>
@@ -175,7 +219,7 @@ var PlatformConfig = (function() {
                         </tr>
                     </table>
                 </td>
-                
+
                 <!-- Weapon Management Section -->
                 <td class="section-cell">
                     <strong>Weapon Management</strong>
@@ -184,7 +228,7 @@ var PlatformConfig = (function() {
                             <thead>
                                 <tr>
                                     <th>Weapon Name</th>
-                                    <th>Range</th>
+                                    <th>Range Band</th>
                                     <th>Quantity</th>
                                     <th>Action</th>
                                 </tr>
@@ -225,7 +269,7 @@ var PlatformConfig = (function() {
                         <button id="addSubgroupButton">Add Subgroup</button>
                     </div>
                 </td>
-                
+
                 <!-- Sensor Management Section -->
                 <td class="section-cell">
                     <strong>Sensor Management</strong>
@@ -234,7 +278,7 @@ var PlatformConfig = (function() {
                             <thead>
                                 <tr>
                                     <th>Sensor Name</th>
-                                    <th>Range</th>
+                                    <th>Range Band</th>
                                     <th>Action</th>
                                 </tr>
                             </thead>
@@ -249,14 +293,14 @@ var PlatformConfig = (function() {
                 </td>
             </tr>
         </table>
-    
+
         <!-- Action Buttons -->
         <div class="action-buttons">
             <button id="updatePlatformButton">Update</button>
             <button id="deletePlatformButton" class="delete-button">Delete</button>
         </div>
     `;
-    
+
         // Display the platform dialog content
         $('#platformInfoContent').html(content);
         $('#platformInfoDialog').dialog('open');
@@ -264,7 +308,7 @@ var PlatformConfig = (function() {
         // ########################################################################
         // PLATFORM WEAPON CONFIGURATION SETUP
         // ########################################################################
-        
+
         // Initialize DataTable for weapons currently equipped on the platform
         var weaponsData = platform.weapons || [];
         var weaponDataArray = WeaponStorage.getWeaponData();
@@ -275,18 +319,18 @@ var PlatformConfig = (function() {
                 var weaponDetails = weaponDataArray.find(function(w) {
                     return w.weapon_name === weapon.name;
                 });
-                // If weapon details are found, get the range, otherwise show 'N/A'
-                var weaponRange = weaponDetails ? weaponDetails.weapon_range : 'N/A';
+                // If weapon details are found, show the min/max range band, otherwise show 'N/A'
+                var weaponRangeBand = formatWeaponRangeBand(weaponDetails);
                 return [
                     weapon.name,
-                    weaponRange,
+                    weaponRangeBand,
                     weapon.quantity,
                     '<button class="removeWeaponButton">Remove</button>'
                 ];
             }),
             columns: [
                 { title: "Weapon Name" },
-                { title: "Range" },
+                { title: "Range Band" },
                 { title: "Quantity" },
                 { title: "Action" }
             ],
@@ -315,7 +359,7 @@ var PlatformConfig = (function() {
                 <div>
                     <label for="weaponSelect">Select Weapon:</label>
                     <select id="weaponSelect">
-                        ${availableWeapons.map(weapon => `<option value="${weapon.weapon_name}">${weapon.weapon_name} (Range: ${weapon.weapon_range})</option>`).join('')}
+                        ${availableWeapons.map(weapon => `<option value="${weapon.weapon_name}">${weapon.weapon_name} (Range Band: ${formatWeaponRangeBand(weapon)})</option>`).join('')}
                     </select>
                     <br><br>
                     <label for="weaponQuantityInput">Quantity:</label>
@@ -349,7 +393,7 @@ var PlatformConfig = (function() {
                             if (weaponDetails) {
                                 weaponsTable.row.add([
                                     weaponDetails.weapon_name,
-                                    weaponDetails.weapon_range,
+                                    formatWeaponRangeBand(weaponDetails),
                                     selectedWeaponQuantity,
                                     '<button class="removeWeaponButton">Remove</button>'
                                 ]).draw();
@@ -374,7 +418,7 @@ var PlatformConfig = (function() {
         // ########################################################################
         // PLATFORM SENSOR CONFIGURATION SETUP
         // ########################################################################
-        
+
         // Initialize DataTable for sensors currently equipped on the platform
         var sensorsData = platform.sensors || [];
         var sensorDataArray = SensorStorage.getSensorData();
@@ -385,17 +429,17 @@ var PlatformConfig = (function() {
                 var sensorDetails = sensorDataArray.find(function(s) {
                     return s.sensor_name === sensor;
                 });
-                // If sensor details are found, get the range, otherwise show 'N/A'
-                var sensorRange = sensorDetails ? sensorDetails.sensor_range : 'N/A';
+                // If sensor details are found, show the min/max range band, otherwise show 'N/A'
+                var sensorRangeBand = formatSensorRangeBand(sensorDetails);
                 return [
                     sensor,
-                    sensorRange,
+                    sensorRangeBand,
                     '<button class="removeSensorButton">Remove</button>'
                 ];
             }),
             columns: [
                 { title: "Sensor Name" },
-                { title: "Range" },
+                { title: "Range Band" },
                 { title: "Action" }
             ],
             searching: false,
@@ -423,7 +467,7 @@ var PlatformConfig = (function() {
                 <div>
                     <label for="sensorSelect">Select Sensor:</label>
                     <select id="sensorSelect">
-                        ${availableSensors.map(sensor => `<option value="${sensor.sensor_name}">${sensor.sensor_name} (Range: ${sensor.sensor_range})</option>`).join('')}
+                        ${availableSensors.map(sensor => `<option value="${sensor.sensor_name}">${sensor.sensor_name} (Range Band: ${formatSensorRangeBand(sensor)})</option>`).join('')}
                     </select>
                     <br><br>
                 </div>
@@ -454,7 +498,7 @@ var PlatformConfig = (function() {
                             if (sensorDetails) {
                                 sensorsTable.row.add([
                                     sensorDetails.sensor_name,
-                                    sensorDetails.sensor_range,
+                                    formatSensorRangeBand(sensorDetails),
                                     '<button class="removeSensorButton">Remove</button>'
                                 ]).draw();
                             }
@@ -639,7 +683,7 @@ var PlatformConfig = (function() {
             platformToUpdate.subgroups = updatedSubgroupsData;
         }
     }
-    
+
     return {
         createPlatformDialog: createPlatformDialog
     }

--- a/js/sensors/sensor_config.js
+++ b/js/sensors/sensor_config.js
@@ -55,6 +55,50 @@ var SensorConfig = (function() {
         return optionsHtml;
     }
 
+    function parseRangeInput(value) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.parseRange) {
+            return RangeUtils.parseRange(value);
+        }
+        if (value === undefined || value === null || value === '') {
+            return null;
+        }
+        var parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    function getSensorRangeBand(sensor) {
+        if (SensorStorage.getSensorRangeBand) {
+            return SensorStorage.getSensorRangeBand(sensor);
+        }
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.getSensorRangeBand) {
+            return RangeUtils.getSensorRangeBand(sensor);
+        }
+        return {
+            min: parseRangeInput(sensor && sensor.sensor_min_range) || 0,
+            max: parseRangeInput(sensor && (sensor.sensor_max_range !== undefined ? sensor.sensor_max_range : sensor.sensor_range)) || 0
+        };
+    }
+
+    function validateSensorRangeBand(minRange, maxRange) {
+        var errors = [];
+        if (minRange === null) {
+            errors.push('Minimum range must be a numeric value.');
+        }
+        if (maxRange === null) {
+            errors.push('Maximum range must be a numeric value.');
+        }
+        if (minRange !== null && minRange < 0) {
+            errors.push('Minimum range cannot be negative.');
+        }
+        if (maxRange !== null && maxRange < 0) {
+            errors.push('Maximum range cannot be negative.');
+        }
+        if (minRange !== null && maxRange !== null && minRange > maxRange) {
+            errors.push('Minimum range cannot be greater than maximum range.');
+        }
+        return errors;
+    }
+
     // Function to create platform info dialog with inputs
     function createSensorConfigDialog() {
         var sensorData = SensorStorage.getSensorData();
@@ -63,19 +107,22 @@ var SensorConfig = (function() {
         var content = '<table id="sensorTable" class="display"><thead><tr>' +
             '<th>Name</th>' +
             '<th>Side</th>' +
-            '<th>Max Range</th>' +
+            '<th>Minimum Range (m)</th>' +
+            '<th>Maximum Range (m)</th>' +
             '<th>Actions</th>' +
             '</tr></thead><tbody>';
 
         // Populate the table with sensor data
         sensorData.forEach(function(sensor, index) {
             var sideOptions = buildSideOptions(sensor && sensor.side);
+            var rangeBand = getSensorRangeBand(sensor);
             content += '<tr>' +
                 '<td><input type="text" value="' + sensor.sensor_name + '" class="sensor-name" data-index="' + index + '" maxlength="32" /></td>' +
                 '<td><select class="sensor-side" data-index="' + index + '">' +
                 sideOptions +
                 '</select></td>' +
-                '<td><input type="number" value="' + sensor.sensor_range + '" class="sensor-range" data-index="' + index + '" /></td>' +
+                '<td><input type="number" value="' + rangeBand.min + '" class="sensor-min-range" data-index="' + index + '" min="0" step="any" /></td>' +
+                '<td><input type="number" value="' + rangeBand.max + '" class="sensor-max-range" data-index="' + index + '" min="0" step="any" /></td>' +
                 '<td><button class="delete-sensor" data-index="' + index + '">Delete</button></td>' +
                 '</tr>';
         });
@@ -102,8 +149,8 @@ var SensorConfig = (function() {
     }
 
     function updateAllSensorsInStorage() {
-        var isValid = true;
         var sensorData = [];
+        var errors = [];
 
         // Use DataTables API to get all rows, regardless of pagination
         var table = $('#sensorTable').DataTable();
@@ -114,26 +161,35 @@ var SensorConfig = (function() {
             var index = $(this).find('.sensor-name').data('index');
             var name = $(this).find('.sensor-name').val().trim();
             var side = $(this).find('.sensor-side').val() || getDefaultSideId();
-            var range = parseInt($(this).find('.sensor-range').val(), 10);
-        
-            // Save old name for updating platformData
-            var oldName = SensorStorage.getSensorData()[index].sensor_name;
-        
-            // Update platformData if the name has changed
-            if (oldName !== name) {
-                updatePlatformSensorReferences(oldName, name);
+            var minRange = parseRangeInput($(this).find('.sensor-min-range').val());
+            var maxRange = parseRangeInput($(this).find('.sensor-max-range').val());
+            var existingSensor = SensorStorage.getSensorData()[index] || {};
+            var oldName = existingSensor.sensor_name;
+            var rangeErrors = validateSensorRangeBand(minRange, maxRange);
+
+            if (!name) {
+                errors.push('Sensor name cannot be empty.');
             }
-        
-            // Collect data for validation
+
+            rangeErrors.forEach(function(error) {
+                errors.push((name || oldName || 'Unnamed sensor') + ': ' + error);
+            });
+
+            // Collect data for validation and storage update. Keep sensor_range
+            // synchronized as a migration fallback for code that has not yet
+            // moved to canonical min/max fields.
             sensorData.push({
-                index: index,
+                oldName: oldName,
                 sensor_name: name,
                 side: side,
-                sensor_range: range
+                sensor_min_range: minRange,
+                sensor_max_range: maxRange,
+                sensor_range: maxRange
             });
         });
-        
-        if (!isValid) {
+
+        if (errors.length > 0) {
+            alert(errors.join('\n'));
             return;
         }
 
@@ -145,11 +201,20 @@ var SensorConfig = (function() {
             return;
         }
 
+        sensorData.forEach(function(sensor) {
+            if (sensor.oldName !== sensor.sensor_name) {
+                updatePlatformSensorReferences(sensor.oldName, sensor.sensor_name);
+            }
+            delete sensor.oldName;
+        });
+
         // Update SensorStorage with the new data
         SensorStorage.setSensorData(sensorData);
 
         // Update range rings and redraw on the map
         RangeRingStorage.init();
+        RangeRingLogic.drawRangeRings();
+        View.updateAll();
 
         // Optionally, close the dialog or provide a success message
         alert('Sensor data has been updated successfully.');
@@ -178,6 +243,10 @@ var SensorConfig = (function() {
             <div id="addSensorDialogContent">
                 <label for="newSensorName">Sensor Name:</label>
                 <input type="text" id="newSensorName" class="ui-widget-content ui-corner-all" style="width: 100%;" maxlength="32" />
+                <label for="newSensorMinRange" style="display:block; margin-top: 10px;">Minimum Range (m):</label>
+                <input type="number" id="newSensorMinRange" class="ui-widget-content ui-corner-all" style="width: 100%;" value="0" min="0" step="any" />
+                <label for="newSensorMaxRange" style="display:block; margin-top: 10px;">Maximum Range (m):</label>
+                <input type="number" id="newSensorMaxRange" class="ui-widget-content ui-corner-all" style="width: 100%;" value="0" min="0" step="any" />
                 <div style="margin-top: 10px; text-align: right;">
                     <button id="completeAddSensor">Complete</button>
                 </div>
@@ -192,7 +261,7 @@ var SensorConfig = (function() {
             title: "Add New Sensor",
             modal: true,
             resizable: false,
-            width: 300,
+            width: 360,
             close: function() {
                 $(this).dialog('destroy').remove();
             }
@@ -200,6 +269,9 @@ var SensorConfig = (function() {
 
         $('#completeAddSensor').off('click').on('click', function() {
             const sensorName = $('#newSensorName').val().trim();
+            var minRange = parseRangeInput($('#newSensorMinRange').val());
+            var maxRange = parseRangeInput($('#newSensorMaxRange').val());
+            var rangeErrors = validateSensorRangeBand(minRange, maxRange);
 
             if (!sensorName) {
                 alert("Sensor name cannot be empty. Please enter a valid name.");
@@ -211,21 +283,32 @@ var SensorConfig = (function() {
                 return;
             }
 
-            addSensorToStorage(sensorName, getDefaultSideId(), 0);
+            if (rangeErrors.length > 0) {
+                alert(rangeErrors.join('\n'));
+                return;
+            }
+
+            addSensorToStorage(sensorName, getDefaultSideId(), minRange, maxRange);
             $('#addSensorDialogContent').dialog('close');
             createSensorConfigDialog();
         });
     }
 
-    function addSensorToStorage(name, side, maxRange) {
+    function addSensorToStorage(name, side, minRange, maxRange) {
         if (name.trim() === '') {
             alert('Sensor name cannot be empty. Please enter a valid name.');
         } else if (isUniqueSensorName(name)) {
-            SensorStorage.getSensorData().push({
+            var sensor = {
                 sensor_name: name,
                 side: side || getDefaultSideId(),
+                sensor_min_range: minRange,
+                sensor_max_range: maxRange,
                 sensor_range: maxRange
-            });
+            };
+            if (typeof RangeUtils !== 'undefined' && RangeUtils.normalizeSensorRecord) {
+                sensor = RangeUtils.normalizeSensorRecord(sensor);
+            }
+            SensorStorage.getSensorData().push(sensor);
         } else {
             alert('Sensor name must be unique. Please choose a different name.');
         }

--- a/js/weapons/weapon_config.js
+++ b/js/weapons/weapon_config.js
@@ -55,6 +55,50 @@ var WeaponConfig = (function() {
         return optionsHtml;
     }
 
+    function parseRangeInput(value) {
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.parseRange) {
+            return RangeUtils.parseRange(value);
+        }
+        if (value === undefined || value === null || value === '') {
+            return null;
+        }
+        var parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    function getWeaponRangeBand(weapon) {
+        if (WeaponStorage.getWeaponRangeBand) {
+            return WeaponStorage.getWeaponRangeBand(weapon);
+        }
+        if (typeof RangeUtils !== 'undefined' && RangeUtils.getWeaponRangeBand) {
+            return RangeUtils.getWeaponRangeBand(weapon);
+        }
+        return {
+            min: parseRangeInput(weapon && weapon.weapon_min_range) || 0,
+            max: parseRangeInput(weapon && (weapon.weapon_max_range !== undefined ? weapon.weapon_max_range : weapon.weapon_range)) || 0
+        };
+    }
+
+    function validateWeaponRangeBand(minRange, maxRange) {
+        var errors = [];
+        if (minRange === null) {
+            errors.push('Minimum range must be a numeric value.');
+        }
+        if (maxRange === null) {
+            errors.push('Maximum range must be a numeric value.');
+        }
+        if (minRange !== null && minRange < 0) {
+            errors.push('Minimum range cannot be negative.');
+        }
+        if (maxRange !== null && maxRange < 0) {
+            errors.push('Maximum range cannot be negative.');
+        }
+        if (minRange !== null && maxRange !== null && minRange > maxRange) {
+            errors.push('Minimum range cannot be greater than maximum range.');
+        }
+        return errors;
+    }
+
     // Function to create platform info dialog with inputs
     function createWeaponConfigDialog() {
         var weaponData = WeaponStorage.getWeaponData();
@@ -63,19 +107,22 @@ var WeaponConfig = (function() {
         var content = '<table id="weaponTable" class="display"><thead><tr>' +
             '<th>Name</th>' +
             '<th>Side</th>' +
-            '<th>Max Range</th>' +
+            '<th>Minimum Range (m)</th>' +
+            '<th>Maximum Range (m)</th>' +
             '<th>Actions</th>' +
             '</tr></thead><tbody>';
 
         // Populate the table with weapon data
         weaponData.forEach(function(weapon, index) {
             var sideOptions = buildSideOptions(weapon && weapon.side);
+            var rangeBand = getWeaponRangeBand(weapon);
             content += '<tr>' +
                 '<td><input type="text" value="' + weapon.weapon_name + '" class="weapon-name" data-index="' + index + '" maxlength="32" /></td>' +
                 '<td><select class="weapon-side" data-index="' + index + '">' +
                 sideOptions +
                 '</select></td>' +
-                '<td><input type="number" value="' + weapon.weapon_range + '" class="weapon-range" data-index="' + index + '" /></td>' +
+                '<td><input type="number" value="' + rangeBand.min + '" class="weapon-min-range" data-index="' + index + '" min="0" step="any" /></td>' +
+                '<td><input type="number" value="' + rangeBand.max + '" class="weapon-max-range" data-index="' + index + '" min="0" step="any" /></td>' +
                 '<td><button class="delete-weapon" data-index="' + index + '">Delete</button></td>' +
                 '</tr>';
         });
@@ -102,42 +149,50 @@ var WeaponConfig = (function() {
     }
 
     function updateAllWeaponsInStorage() {
-        var isValid = true;
         var weaponData = [];
-    
+        var errors = [];
+
         // Use DataTables API to get all rows, regardless of pagination
         var table = $('#weaponTable').DataTable();
         var allRows = table.rows().nodes(); // Get all row nodes
-    
+
         // Iterate over each row in the table
         $(allRows).each(function() {
             var index = $(this).find('.weapon-name').data('index');
             var name = $(this).find('.weapon-name').val().trim();
             var side = $(this).find('.weapon-side').val() || getDefaultSideId();
-            var range = parseInt($(this).find('.weapon-range').val(), 10);
-        
-            // Save old name for updating platformData
-            var oldName = WeaponStorage.getWeaponData()[index].weapon_name;
-        
-            // Update platformData if the name has changed
-            if (oldName !== name) {
-                updatePlatformWeaponReferences(oldName, name);
+            var minRange = parseRangeInput($(this).find('.weapon-min-range').val());
+            var maxRange = parseRangeInput($(this).find('.weapon-max-range').val());
+            var existingWeapon = WeaponStorage.getWeaponData()[index] || {};
+            var oldName = existingWeapon.weapon_name;
+            var rangeErrors = validateWeaponRangeBand(minRange, maxRange);
+
+            if (!name) {
+                errors.push('Weapon name cannot be empty.');
             }
-        
-            // Collect data for validation
+
+            rangeErrors.forEach(function(error) {
+                errors.push((name || oldName || 'Unnamed weapon') + ': ' + error);
+            });
+
+            // Collect data for validation and storage update. Keep weapon_range
+            // synchronized as a migration fallback for code that has not yet
+            // moved to canonical min/max fields.
             weaponData.push({
-                index: index,
+                oldName: oldName,
                 weapon_name: name,
                 side: side,
-                weapon_range: range
+                weapon_min_range: minRange,
+                weapon_max_range: maxRange,
+                weapon_range: maxRange
             });
         });
-        
-    
-        if (!isValid) {
+
+        if (errors.length > 0) {
+            alert(errors.join('\n'));
             return;
         }
-    
+
         // Check for unique weapon names
         var names = weaponData.map(w => w.weapon_name.toLowerCase());
         var hasDuplicates = names.some((name, idx) => names.indexOf(name) !== idx);
@@ -145,16 +200,25 @@ var WeaponConfig = (function() {
             alert('Weapon names must be unique. Please ensure all weapon names are unique.');
             return;
         }
-    
+
+        weaponData.forEach(function(weapon) {
+            if (weapon.oldName !== weapon.weapon_name) {
+                updatePlatformWeaponReferences(weapon.oldName, weapon.weapon_name);
+            }
+            delete weapon.oldName;
+        });
+
         // Update WeaponStorage with the new data
         WeaponStorage.setWeaponData(weaponData);
         // Update range rings and redraw on the map
         RangeRingStorage.init();
-    
+        RangeRingLogic.drawRangeRings();
+        View.updateAll();
+
         // Optionally, close the dialog or provide a success message
         alert('Weapon data has been updated successfully.');
     }
-        
+
     function bindWeaponActions() {
         // Handle delete weapon
         $('#weaponTable').off('click', '.delete-weapon').on('click', '.delete-weapon', function() {
@@ -174,15 +238,21 @@ var WeaponConfig = (function() {
     }
 
     // Function to add a new weapon into weapon storage
-    function addWeaponToStorage(name, side, maxRange) {
+    function addWeaponToStorage(name, side, minRange, maxRange) {
         if (name.trim() === '') {
             alert('Weapon name cannot be empty. Please enter a valid name.');
         } else if (isUniqueWeaponName(name)) {
-            WeaponStorage.getWeaponData().push({
+            var weapon = {
                 weapon_name: name,
                 side: side || getDefaultSideId(),
+                weapon_min_range: minRange,
+                weapon_max_range: maxRange,
                 weapon_range: maxRange
-            });
+            };
+            if (typeof RangeUtils !== 'undefined' && RangeUtils.normalizeWeaponRecord) {
+                weapon = RangeUtils.normalizeWeaponRecord(weapon);
+            }
+            WeaponStorage.getWeaponData().push(weapon);
         } else {
             alert('Weapon name must be unique. Please choose a different name.');
         }
@@ -194,6 +264,10 @@ var WeaponConfig = (function() {
             <div id="addWeaponDialogContent">
                 <label for="newWeaponName">Weapon Name:</label>
                 <input type="text" id="newWeaponName" class="ui-widget-content ui-corner-all" style="width: 100%;" maxlength="32" />
+                <label for="newWeaponMinRange" style="display:block; margin-top: 10px;">Minimum Range (m):</label>
+                <input type="number" id="newWeaponMinRange" class="ui-widget-content ui-corner-all" style="width: 100%;" value="0" min="0" step="any" />
+                <label for="newWeaponMaxRange" style="display:block; margin-top: 10px;">Maximum Range (m):</label>
+                <input type="number" id="newWeaponMaxRange" class="ui-widget-content ui-corner-all" style="width: 100%;" value="0" min="0" step="any" />
                 <div style="margin-top: 10px; text-align: right;">
                     <button id="completeAddWeapon">Complete</button>
                 </div>
@@ -210,7 +284,7 @@ var WeaponConfig = (function() {
             title: "Add New Weapon",
             modal: true,
             resizable: false,
-            width: 300,
+            width: 360,
             close: function() {
                 $(this).dialog('destroy').remove();
             }
@@ -219,6 +293,9 @@ var WeaponConfig = (function() {
         // Bind event for "Complete" button
         $('#completeAddWeapon').off('click').on('click', function() {
             const weaponName = $('#newWeaponName').val().trim();
+            var minRange = parseRangeInput($('#newWeaponMinRange').val());
+            var maxRange = parseRangeInput($('#newWeaponMaxRange').val());
+            var rangeErrors = validateWeaponRangeBand(minRange, maxRange);
     
             // Validate weapon name
             if (!weaponName) {
@@ -230,24 +307,19 @@ var WeaponConfig = (function() {
                 alert("Weapon name must be unique. Please choose a different name.");
                 return;
             }
+
+            if (rangeErrors.length > 0) {
+                alert(rangeErrors.join('\n'));
+                return;
+            }
     
             // Add weapon to storage with default values for side and range
-            addWeaponToStorage(weaponName, getDefaultSideId(), 0);
+            addWeaponToStorage(weaponName, getDefaultSideId(), minRange, maxRange);
     
             // Close dialog and refresh the main weapon config dialog
             $('#addWeaponDialogContent').dialog('close');
             createWeaponConfigDialog();
         });
-    }
-
-    // Function to update weapon data in weapon storage
-    function updateWeaponInStorage(index, name, side, maxRange) {
-        var weaponData = WeaponStorage.getWeaponData();
-        if (index >= 0 && index < weaponData.length) {
-            weaponData[index].weapon_name = name;
-            weaponData[index].side = side;
-            weaponData[index].weapon_range = maxRange;
-        }
     }
 
     function handleWeaponDeletion(index) {


### PR DESCRIPTION
### Motivation
- Move configuration UIs from a single scalar `weapon_range`/`sensor_range` to explicit minimum/maximum range bands so consumers can rely on canonical `*_min_range` / `*_max_range` fields (Phases 1–2 provided normalization/helpers). 
- Provide a single place for validation and user entry to avoid migration divergence and to surface the new semantics in platform assignment dialogs.

### Description
- Weapon and sensor configuration dialogs now present two editable columns: `Minimum Range (m)` and `Maximum Range (m)`, and the add dialogs collect both values; parsing and validation helpers were added: `parseRangeInput`, `validateWeaponRangeBand`, and `validateSensorRangeBand` in `js/weapons/weapon_config.js` and `js/sensors/sensor_config.js` respectively. 
- Add/update flows validate numeric, non-negative inputs and `min <= max`, then store canonical fields `weapon_min_range` / `weapon_max_range` and `sensor_min_range` / `sensor_max_range`, while keeping the legacy `weapon_range` / `sensor_range` synchronized to the max for migration compatibility. 
- Platform dialog and add-item dropdowns were updated to display a formatted "Range Band" (e.g. `10,000 - 50,000 m`) using shared accessors which defer to `RangeUtils` or storage helpers; platform stored records remain references (name + quantity). Changes are in `js/platforms/plat_config.js`. 
- Range ring redraw and results refresh are triggered after edits (`RangeRingStorage.init()`, `RangeRingLogic.drawRangeRings()`, `View.updateAll()`), and weapon/sensor dialogs were widened to accommodate the extra column (`dialog_init.js`). Files changed include `js/weapons/weapon_config.js`, `js/sensors/sensor_config.js`, `js/platforms/plat_config.js`, and `dialog_init.js`.

### Testing
- Static JS checks: ran `node --check js/weapons/weapon_config.js && node --check js/sensors/sensor_config.js && node --check js/platforms/plat_config.js && node --check dialog_init.js` and they succeeded. 
- Repository checks: ran `git diff --check` and fixed whitespace issues reported by the check. 
- Basic serve smoke test: started a local server and verified `http://127.0.0.1:8000/index.html` returned `200` to ensure the modified pages load. 
- UI automation note: no headless browser binary was available in the environment so interactive visual verification (screenshots / end-to-end UI tests) was not executed; manual UI review is recommended in a browser to confirm layout and behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a295ecc0a44832aa59638b7cd66964d)