### PR TITLE
Implement min/max range ring bands

### DIFF
--- a/js/range_rings/range_ring_config.js
+++ b/js/range_rings/range_ring_config.js
@@ -15,7 +15,8 @@ var RangeRingConfig = (function() {
                             <th>Platform Name</th>
                             <th>System Name</th>
                             <th>System Type</th>
-                            <th>Range (m)</th>
+                            <th>Min Range (m)</th>
+                            <th>Max Range (m)</th>
                             <th>Latitude</th>
                             <th>Longitude</th>
                         </tr>
@@ -27,7 +28,8 @@ var RangeRingConfig = (function() {
                                 <td>${ring.platform_name}</td>
                                 <td>${ring.system_name}</td>
                                 <td>${ring.system_type}</td>
-                                <td>${ring.range_val}</td>
+                                <td data-order="${getRangeMinValue(ring)}">${formatRangeValue(getRangeMinValue(ring))}</td>
+                                <td data-order="${getRangeMaxValue(ring)}">${formatRangeValue(getRangeMaxValue(ring))}</td>
                                 <td>${ring.latitude}</td>
                                 <td>${ring.longitude}</td>
                             </tr>
@@ -90,6 +92,49 @@ var RangeRingConfig = (function() {
         $('#editRangeRingStyleButton').on('click', function() {
             RangeRingStyleEditor.createEditStyleDialog();
         });
+    }
+
+    function getRangeMinValue(ring) {
+        var value = ring && ring.range_min_val;
+        if (value === undefined && ring) {
+            value = ring.min_range_val;
+        }
+        if (value === undefined) {
+            value = 0;
+        }
+        var parsed = parseRangeValue(value);
+        return parsed === null ? 0 : parsed;
+    }
+
+    function getRangeMaxValue(ring) {
+        var value = ring && ring.range_max_val;
+        if (value === undefined && ring) {
+            value = ring.max_range_val;
+        }
+        if (value === undefined && ring) {
+            value = ring.range_val;
+        }
+        var parsed = parseRangeValue(value);
+        return parsed === null ? NaN : parsed;
+    }
+
+    function parseRangeValue(value) {
+        if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.parseRange === 'function') {
+            return RangeUtils.parseRange(value);
+        }
+        if (value === undefined || value === null || value === '') {
+            return null;
+        }
+        var parsed = Number(value);
+        return isFinite(parsed) ? parsed : null;
+    }
+
+    function formatRangeValue(value) {
+        if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.formatRange === 'function') {
+            return RangeUtils.formatRange(value);
+        }
+        var parsed = parseRangeValue(value);
+        return parsed === null ? 'Unknown' : parsed.toLocaleString();
     }
 
     return {

--- a/js/range_rings/range_ring_logic.js
+++ b/js/range_rings/range_ring_logic.js
@@ -16,36 +16,97 @@ var RangeRingLogic = (function() {
 
     rangeRings
       .filter(function(rangeRing) { return rangeRing.toggled === 1; })
-      .sort(function(a, b) { return b.range_val - a.range_val; })
+      .sort(function(a, b) { return getRangeMaxValue(b) - getRangeMaxValue(a); })
       .forEach(function(rangeRing) {
+        var maxRange = getRangeMaxValue(rangeRing);
+        var minRange = getRangeMinValue(rangeRing);
+        if (!isFinite(maxRange)) { return; }
+
         var style = getRangeRingStyle(rangeRing, platformSideLookup[rangeRing.platform_name]);
-        var circle = L.circle([rangeRing.latitude, rangeRing.longitude], {
-          radius: rangeRing.range_val,
+        var outerCircle = L.circle([rangeRing.latitude, rangeRing.longitude], {
+          radius: maxRange,
           color: style.color,
           weight: style.lineWidth,
           opacity: style.opacity,
           fillOpacity: 0.01
         });
 
-        var rangeValue = typeof rangeRing.range_val === 'number' ? rangeRing.range_val : parseFloat(rangeRing.range_val);
-        var formattedRange = isFinite(rangeValue) ? rangeValue.toLocaleString() : 'Unknown';
         var tooltipContent = [
           rangeRing.system_name || 'Unknown System',
           rangeRing.platform_name || 'Unknown Platform',
-          formattedRange + ' m'
+          'Min: ' + formatRangeValue(minRange) + ' m',
+          'Max: ' + formatRangeValue(maxRange) + ' m'
         ].join('<br>');
 
-        circle.bindTooltip(tooltipContent, {
+        outerCircle.bindTooltip(tooltipContent, {
           direction: 'top',
           sticky: true,
           className: 'range-ring-tooltip'
         });
 
-        circle.addTo(map);
-        rangeRingLayers.push(circle);
+        outerCircle.addTo(map);
+        rangeRingLayers.push(outerCircle);
+
+        if (isFinite(minRange) && minRange > 0) {
+          var innerCircle = L.circle([rangeRing.latitude, rangeRing.longitude], {
+            radius: minRange,
+            color: style.color,
+            weight: Math.max(1, style.lineWidth - 1),
+            opacity: style.opacity,
+            fillOpacity: 0,
+            dashArray: '6 6'
+          });
+
+          innerCircle.addTo(map);
+          rangeRingLayers.push(innerCircle);
+        }
       });
 
     updateRangeRingConfigCheckboxes();
+  }
+
+
+  function getRangeMinValue(rangeRing) {
+    var value = rangeRing && rangeRing.range_min_val;
+    if (value === undefined && rangeRing) {
+      value = rangeRing.min_range_val;
+    }
+    if (value === undefined) {
+      value = 0;
+    }
+    var parsed = parseRangeValue(value);
+    return parsed === null ? 0 : parsed;
+  }
+
+  function getRangeMaxValue(rangeRing) {
+    var value = rangeRing && rangeRing.range_max_val;
+    if (value === undefined && rangeRing) {
+      value = rangeRing.max_range_val;
+    }
+    if (value === undefined && rangeRing) {
+      value = rangeRing.range_val;
+    }
+    var parsed = parseRangeValue(value);
+    return parsed === null ? NaN : parsed;
+  }
+
+  function parseRangeValue(value) {
+    if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.parseRange === 'function') {
+      return RangeUtils.parseRange(value);
+    }
+    if (value === undefined || value === null || value === '') {
+      return null;
+    }
+    var parsed = Number(value);
+    return isFinite(parsed) ? parsed : null;
+  }
+
+  function formatRangeValue(value) {
+    if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.formatRange === 'function') {
+      return RangeUtils.formatRange(value);
+    }
+    var parsed = parseRangeValue(value);
+    return parsed === null ? 'Unknown' : parsed.toLocaleString();
   }
 
   function drawRangeRingForPlatform(platformName) {

--- a/js/range_rings/range_ring_storage.js
+++ b/js/range_rings/range_ring_storage.js
@@ -25,38 +25,107 @@ var RangeRingStorage = (function() {
 
             if (platform.weapons) {
                 platform.weapons.forEach(function(weapon) {
-                    if (weaponDict[weapon.name]) {
-                        rangeRings.push({
-                            platform_name: platform.platform_name,
-                            system_name: weapon.name,
-                            system_type: "weapon",
-                            range_val: weaponDict[weapon.name].weapon_range,
-                            latitude: parseFloat(platform.latitude),
-                            longitude: parseFloat(platform.longitude),
+                    var weaponDetails = weaponDict[weapon.name];
+                    if (weaponDetails) {
+                        var weaponBand = getWeaponRangeBand(weaponDetails);
+                        rangeRings.push(createRangeRingRecord({
+                            platform: platform,
+                            systemName: weapon.name,
+                            systemType: "weapon",
+                            rangeBand: weaponBand,
                             toggled: setToggled,
-                            style: Object.assign({}, defaultStyle)
-                        });
+                            style: defaultStyle
+                        }));
                     }
                 });
             }
 
             if (platform.sensors) {
                 platform.sensors.forEach(function(sensorName) {
-                    if (sensorDict[sensorName]) {
-                        rangeRings.push({
-                            platform_name: platform.platform_name,
-                            system_name: sensorName,
-                            system_type: "sensor",
-                            range_val: sensorDict[sensorName].sensor_range,
-                            latitude: parseFloat(platform.latitude),
-                            longitude: parseFloat(platform.longitude),
+                    var sensorDetails = sensorDict[sensorName];
+                    if (sensorDetails) {
+                        var sensorBand = getSensorRangeBand(sensorDetails);
+                        rangeRings.push(createRangeRingRecord({
+                            platform: platform,
+                            systemName: sensorName,
+                            systemType: "sensor",
+                            rangeBand: sensorBand,
                             toggled: setToggled,
-                            style: Object.assign({}, defaultStyle)
-                        });
+                            style: defaultStyle
+                        }));
                     }
                 });
             }
         });
+    }
+
+    function createRangeRingRecord(options) {
+        var rangeBand = normalizeRangeBand(options.rangeBand);
+        return {
+            platform_name: options.platform.platform_name,
+            system_name: options.systemName,
+            system_type: options.systemType,
+            range_min_val: rangeBand.min,
+            range_max_val: rangeBand.max,
+            latitude: parseFloat(options.platform.latitude),
+            longitude: parseFloat(options.platform.longitude),
+            toggled: options.toggled,
+            style: Object.assign({}, options.style)
+        };
+    }
+
+    function getWeaponRangeBand(weapon) {
+        if (typeof WeaponStorage !== 'undefined' && typeof WeaponStorage.getWeaponRangeBand === 'function') {
+            return WeaponStorage.getWeaponRangeBand(weapon);
+        }
+        if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.getWeaponRangeBand === 'function') {
+            return RangeUtils.getWeaponRangeBand(weapon);
+        }
+        return normalizeRangeBand({
+            min: weapon && weapon.weapon_min_range,
+            max: weapon && (weapon.weapon_max_range !== undefined ? weapon.weapon_max_range : weapon.weapon_range)
+        });
+    }
+
+    function getSensorRangeBand(sensor) {
+        if (typeof SensorStorage !== 'undefined' && typeof SensorStorage.getSensorRangeBand === 'function') {
+            return SensorStorage.getSensorRangeBand(sensor);
+        }
+        if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.getSensorRangeBand === 'function') {
+            return RangeUtils.getSensorRangeBand(sensor);
+        }
+        return normalizeRangeBand({
+            min: sensor && sensor.sensor_min_range,
+            max: sensor && (sensor.sensor_max_range !== undefined ? sensor.sensor_max_range : sensor.sensor_range)
+        });
+    }
+
+    function normalizeRangeBand(rangeBand) {
+        var minRange = parseRange(rangeBand && (rangeBand.min !== undefined ? rangeBand.min : rangeBand.range_min_val));
+        var maxRange = parseRange(rangeBand && (rangeBand.max !== undefined ? rangeBand.max : rangeBand.range_max_val));
+
+        if (minRange === null) { minRange = 0; }
+        if (maxRange === null) { maxRange = minRange; }
+
+        minRange = Math.max(0, minRange);
+        maxRange = Math.max(0, maxRange);
+
+        if (minRange > maxRange) {
+            maxRange = minRange;
+        }
+
+        return { min: minRange, max: maxRange };
+    }
+
+    function parseRange(value) {
+        if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.parseRange === 'function') {
+            return RangeUtils.parseRange(value);
+        }
+        if (value === undefined || value === null || value === '') {
+            return null;
+        }
+        var parsed = Number(value);
+        return isFinite(parsed) ? parsed : null;
     }
 
     function getDefaultStyleForSide(side) {


### PR DESCRIPTION
### Motivation
- Convert range-ring storage and rendering from a single scalar `range_val` to a canonical min/max range band so range rings represent an engagement/detection band (phase 4 of the plan). 
- Preserve one logical identity per platform/system (single toggle/style) while remaining backward-compatible with legacy `range_val`/`weapon_range`/`sensor_range` fields.

### Description
- Replace per-ring `range_val` with `range_min_val` and `range_max_val` produced by `createRangeRingRecord()` and normalized via `normalizeRangeBand()` in `js/range_rings/range_ring_storage.js` while using `WeaponStorage`/`SensorStorage` or `RangeUtils` helpers when available. 
- Update `RangeRingLogic.drawRangeRings()` to sort by maximum range, draw an outer circle at `max` and a dashed inner circle at `min` (when `min > 0`), and show both `Min`/`Max` in the tooltip in `js/range_rings/range_ring_logic.js`. 
- Add accessor/formatting helpers and legacy fallbacks (`getRangeMinValue`, `getRangeMaxValue`, `parseRangeValue`, `formatRangeValue`) used by logic and UI to maintain compatibility with older records. 
- Replace the single `Range (m)` column with `Min Range (m)` and `Max Range (m)` (sortable and formatted) in the range-ring configuration dialog in `js/range_rings/range_ring_config.js` while preserving toggle behavior and style editor integration.

### Testing
- Ran static JS checks with `node --check` across affected scripts and the repository without syntax errors, which succeeded. 
- Executed a storage smoke test in a Node VM that instantiated `RangeRingStorage.init()` with weapon and sensor fixtures and asserted `range_min_val`/`range_max_val` values and that legacy `range_val` is not persisted, which passed. 
- Executed a rendering smoke test in a Node VM that ran `RangeRingLogic.drawRangeRings()` with mocked `L.circle` and asserted outer/inner circles, radii, dashed inner styling, and tooltip contents, which passed. 
- UI screenshot capture was not possible because no browser/screenshot tool is available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a297ab33b80832abd5ffaa94e5f8abc)