### PR TITLE
Implement min/max range ring support

### DIFF
--- a/js/range_rings/range_ring_config.js
+++ b/js/range_rings/range_ring_config.js
@@ -15,7 +15,8 @@ var RangeRingConfig = (function() {
                             <th>Platform Name</th>
                             <th>System Name</th>
                             <th>System Type</th>
-                            <th>Range (m)</th>
+                            <th>Minimum Range (m)</th>
+                            <th>Maximum Range (m)</th>
                             <th>Latitude</th>
                             <th>Longitude</th>
                         </tr>
@@ -27,7 +28,8 @@ var RangeRingConfig = (function() {
                                 <td>${ring.platform_name}</td>
                                 <td>${ring.system_name}</td>
                                 <td>${ring.system_type}</td>
-                                <td>${ring.range_val}</td>
+                                <td data-order="${getRangeMinValue(ring)}">${formatRangeValue(getRangeMinValue(ring))}</td>
+                                <td data-order="${getRangeMaxValue(ring)}">${formatRangeValue(getRangeMaxValue(ring))}</td>
                                 <td>${ring.latitude}</td>
                                 <td>${ring.longitude}</td>
                             </tr>
@@ -90,6 +92,37 @@ var RangeRingConfig = (function() {
         $('#editRangeRingStyleButton').on('click', function() {
             RangeRingStyleEditor.createEditStyleDialog();
         });
+    }
+
+    function getRangeMinValue(ring) {
+        var parsed = parseRangeValue(ring && ring.range_min_val);
+        return parsed === null ? 0 : parsed;
+    }
+
+    function getRangeMaxValue(ring) {
+        var parsed = parseRangeValue(ring && ring.range_max_val);
+        if (parsed === null) {
+            parsed = parseRangeValue(ring && ring.range_val);
+        }
+        return parsed === null ? '' : parsed;
+    }
+
+    function parseRangeValue(value) {
+        if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.parseRange === 'function') {
+            return RangeUtils.parseRange(value);
+        }
+
+        var parsed = typeof value === 'number' ? value : parseFloat(value);
+        return isFinite(parsed) ? parsed : null;
+    }
+
+    function formatRangeValue(value) {
+        if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.formatRange === 'function') {
+            return RangeUtils.formatRange(value);
+        }
+
+        var parsed = parseRangeValue(value);
+        return parsed === null ? 'Unknown' : parsed.toLocaleString();
     }
 
     return {

--- a/js/range_rings/range_ring_logic.js
+++ b/js/range_rings/range_ring_logic.js
@@ -16,33 +16,45 @@ var RangeRingLogic = (function() {
 
     rangeRings
       .filter(function(rangeRing) { return rangeRing.toggled === 1; })
-      .sort(function(a, b) { return b.range_val - a.range_val; })
+      .sort(function(a, b) { return getRangeMaxValue(b) - getRangeMaxValue(a); })
       .forEach(function(rangeRing) {
+        var rangeBand = getRangeRingBand(rangeRing);
+        if (!isValidRangeBand(rangeBand)) {
+          return;
+        }
+
         var style = getRangeRingStyle(rangeRing, platformSideLookup[rangeRing.platform_name]);
-        var circle = L.circle([rangeRing.latitude, rangeRing.longitude], {
-          radius: rangeRing.range_val,
+        var tooltipContent = createRangeBandTooltip(rangeRing, rangeBand);
+        var outerCircle = L.circle([rangeRing.latitude, rangeRing.longitude], {
+          radius: rangeBand.max,
           color: style.color,
           weight: style.lineWidth,
           opacity: style.opacity,
           fillOpacity: 0.01
         });
 
-        var rangeValue = typeof rangeRing.range_val === 'number' ? rangeRing.range_val : parseFloat(rangeRing.range_val);
-        var formattedRange = isFinite(rangeValue) ? rangeValue.toLocaleString() : 'Unknown';
-        var tooltipContent = [
-          rangeRing.system_name || 'Unknown System',
-          rangeRing.platform_name || 'Unknown Platform',
-          formattedRange + ' m'
-        ].join('<br>');
-
-        circle.bindTooltip(tooltipContent, {
+        outerCircle.bindTooltip(tooltipContent, {
           direction: 'top',
           sticky: true,
           className: 'range-ring-tooltip'
         });
 
-        circle.addTo(map);
-        rangeRingLayers.push(circle);
+        outerCircle.addTo(map);
+        rangeRingLayers.push(outerCircle);
+
+        if (rangeBand.min > 0) {
+          var innerCircle = L.circle([rangeRing.latitude, rangeRing.longitude], {
+            radius: rangeBand.min,
+            color: style.color,
+            weight: Math.max(1, Math.round(style.lineWidth * 0.75)),
+            opacity: style.opacity,
+            fillOpacity: 0,
+            dashArray: '6 6'
+          });
+
+          innerCircle.addTo(map);
+          rangeRingLayers.push(innerCircle);
+        }
       });
 
     updateRangeRingConfigCheckboxes();
@@ -102,6 +114,67 @@ var RangeRingLogic = (function() {
 
   function createRangeRingKey(platformName, systemName) {
     return String(platformName) + '|' + String(systemName);
+  }
+
+  function getRangeRingBand(rangeRing) {
+    var min = parseRangeValue(rangeRing.range_min_val);
+    var max = parseRangeValue(rangeRing.range_max_val);
+
+    if (min === null) {
+      min = 0;
+    }
+    if (max === null) {
+      max = parseRangeValue(rangeRing.range_val);
+    }
+
+    return {
+      min: min,
+      max: max
+    };
+  }
+
+  function getRangeMaxValue(rangeRing) {
+    var rangeBand = getRangeRingBand(rangeRing);
+    return rangeBand.max === null ? -Infinity : rangeBand.max;
+  }
+
+  function parseRangeValue(value) {
+    if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.parseRange === 'function') {
+      return RangeUtils.parseRange(value);
+    }
+
+    var parsed = typeof value === 'number' ? value : parseFloat(value);
+    return isFinite(parsed) ? parsed : null;
+  }
+
+  function isValidRangeBand(rangeBand) {
+    if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.isValidRangeBand === 'function') {
+      return RangeUtils.isValidRangeBand(rangeBand.min, rangeBand.max);
+    }
+
+    return isFinite(rangeBand.min) &&
+      isFinite(rangeBand.max) &&
+      rangeBand.min >= 0 &&
+      rangeBand.max >= 0 &&
+      rangeBand.min <= rangeBand.max;
+  }
+
+  function formatRangeValue(value) {
+    if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.formatRange === 'function') {
+      return RangeUtils.formatRange(value);
+    }
+
+    var parsed = parseRangeValue(value);
+    return parsed === null ? 'Unknown' : parsed.toLocaleString();
+  }
+
+  function createRangeBandTooltip(rangeRing, rangeBand) {
+    return [
+      rangeRing.system_name || 'Unknown System',
+      rangeRing.platform_name || 'Unknown Platform',
+      'Min: ' + formatRangeValue(rangeBand.min) + ' m',
+      'Max: ' + formatRangeValue(rangeBand.max) + ' m'
+    ].join('<br>');
   }
 
   function getRangeRingStyle(rangeRing, side) {

--- a/js/range_rings/range_ring_storage.js
+++ b/js/range_rings/range_ring_storage.js
@@ -7,6 +7,7 @@ var RangeRingStorage = (function() {
         var weaponData = WeaponStorage.getWeaponData();
         var sensorData = SensorStorage.getSensorData();
         var setToggled = 0;
+        var existingRangeRingState = createExistingRangeRingStateLookup(rangeRings);
 
         rangeRings = [];
 
@@ -26,15 +27,23 @@ var RangeRingStorage = (function() {
             if (platform.weapons) {
                 platform.weapons.forEach(function(weapon) {
                     if (weaponDict[weapon.name]) {
+                        var weaponBand = getWeaponRangeBand(weaponDict[weapon.name]);
+                        var weaponState = getExistingRangeRingState(
+                            existingRangeRingState,
+                            platform.platform_name,
+                            weapon.name
+                        );
+
                         rangeRings.push({
                             platform_name: platform.platform_name,
                             system_name: weapon.name,
                             system_type: "weapon",
-                            range_val: weaponDict[weapon.name].weapon_range,
+                            range_min_val: weaponBand.min,
+                            range_max_val: weaponBand.max,
                             latitude: parseFloat(platform.latitude),
                             longitude: parseFloat(platform.longitude),
-                            toggled: setToggled,
-                            style: Object.assign({}, defaultStyle)
+                            toggled: weaponState && weaponState.toggled !== undefined ? weaponState.toggled : setToggled,
+                            style: weaponState && weaponState.style ? Object.assign({}, weaponState.style) : Object.assign({}, defaultStyle)
                         });
                     }
                 });
@@ -43,20 +52,76 @@ var RangeRingStorage = (function() {
             if (platform.sensors) {
                 platform.sensors.forEach(function(sensorName) {
                     if (sensorDict[sensorName]) {
+                        var sensorBand = getSensorRangeBand(sensorDict[sensorName]);
+                        var sensorState = getExistingRangeRingState(
+                            existingRangeRingState,
+                            platform.platform_name,
+                            sensorName
+                        );
+
                         rangeRings.push({
                             platform_name: platform.platform_name,
                             system_name: sensorName,
                             system_type: "sensor",
-                            range_val: sensorDict[sensorName].sensor_range,
+                            range_min_val: sensorBand.min,
+                            range_max_val: sensorBand.max,
                             latitude: parseFloat(platform.latitude),
                             longitude: parseFloat(platform.longitude),
-                            toggled: setToggled,
-                            style: Object.assign({}, defaultStyle)
+                            toggled: sensorState && sensorState.toggled !== undefined ? sensorState.toggled : setToggled,
+                            style: sensorState && sensorState.style ? Object.assign({}, sensorState.style) : Object.assign({}, defaultStyle)
                         });
                     }
                 });
             }
         });
+    }
+
+    function getWeaponRangeBand(weapon) {
+        if (typeof WeaponStorage !== 'undefined' && typeof WeaponStorage.getWeaponRangeBand === 'function') {
+            return WeaponStorage.getWeaponRangeBand(weapon);
+        }
+        if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.getWeaponRangeBand === 'function') {
+            return RangeUtils.getWeaponRangeBand(weapon);
+        }
+        return {
+            min: weapon && isFinite(weapon.weapon_min_range) ? Number(weapon.weapon_min_range) : 0,
+            max: weapon && isFinite(weapon.weapon_max_range) ? Number(weapon.weapon_max_range) : Number(weapon && weapon.weapon_range),
+            isValid: true
+        };
+    }
+
+    function getSensorRangeBand(sensor) {
+        if (typeof SensorStorage !== 'undefined' && typeof SensorStorage.getSensorRangeBand === 'function') {
+            return SensorStorage.getSensorRangeBand(sensor);
+        }
+        if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.getSensorRangeBand === 'function') {
+            return RangeUtils.getSensorRangeBand(sensor);
+        }
+        return {
+            min: sensor && isFinite(sensor.sensor_min_range) ? Number(sensor.sensor_min_range) : 0,
+            max: sensor && isFinite(sensor.sensor_max_range) ? Number(sensor.sensor_max_range) : Number(sensor && sensor.sensor_range),
+            isValid: true
+        };
+    }
+
+    function createExistingRangeRingStateLookup(existingRangeRings) {
+        if (!Array.isArray(existingRangeRings)) { return {}; }
+
+        return existingRangeRings.reduce(function(lookup, rangeRing) {
+            lookup[createRangeRingKey(rangeRing.platform_name, rangeRing.system_name)] = {
+                toggled: rangeRing.toggled,
+                style: rangeRing.style ? Object.assign({}, rangeRing.style) : undefined
+            };
+            return lookup;
+        }, {});
+    }
+
+    function getExistingRangeRingState(existingRangeRingState, platformName, systemName) {
+        return existingRangeRingState[createRangeRingKey(platformName, systemName)];
+    }
+
+    function createRangeRingKey(platformName, systemName) {
+        return String(platformName) + '|' + String(systemName);
     }
 
     function getDefaultStyleForSide(side) {


### PR DESCRIPTION
### Motivation

- Range rings must represent a min/max engagement/detection band instead of a single scalar to support minimum-range dead zones and more accurate coverage logic.  
- Range ring UI, storage, and rendering need to be updated so the app can display and persist bands while preserving existing toggle/style state.  
- The change needs safe fallbacks to legacy scalar fields during migration so other consumers remain compatible.

### Description

- Updated `RangeRingStorage.init()` to build one record per platform-system that contains `range_min_val` and `range_max_val`, sourced from weapon/sensor range-band accessors and preserving prior `toggled` and `style` state by `platform|system` when rebuilding the list.  
- Replaced single-scalar usage in the renderer: `RangeRingLogic.drawRangeRings()` now sorts by the maximum range, draws an outer circle at `max`, draws a dashed inner circle when `min > 0`, stores both Leaflet layers for cleanup, and shows tooltips with both `Min` and `Max` values.  
- Updated the range ring configuration dialog `RangeRingConfig.createRangeRingConfigDialog()` to display sortable `Minimum Range (m)` and `Maximum Range (m)` columns and added small helpers for parsing/formatting the displayed values.  
- Added localized helpers and fallbacks so storage/logic prefer canonical min/max fields but still read legacy scalar fields (`weapon_range` / `sensor_range`) and use `RangeUtils` when available for normalization/validation.

### Testing

- Ran syntax/type checks with `node --check` on the modified range-ring files and the repository JS files, which completed without errors.  
- Executed a Node-based smoke test (VM with mocked `PlatformModel`, `WeaponStorage`, `SensorStorage`, `View`, and `L.circle`) that verified: min/max bands are stored for weapons/sensors, prior `toggled` and `style` state is preserved across `init()` calls, the renderer produced an outer and inner layer with correct radii and dashed inner ring, and the tooltip includes `Min` and `Max` text; the test passed.  
- No automated browser UI tests were run in this environment due to lack of a browser binary, so visual verification should be performed in a running UI as part of QA.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a297ab33b80832abd5ffaa94e5f8abc)