### PR TITLE
Use min/max range bands in results coverage calculations

### DIFF
--- a/results/js/charts.js
+++ b/results/js/charts.js
@@ -6,14 +6,6 @@
  * the user's selections.
  */
 
-/**
- * Sum the quantity of a particular weapon across a set of platforms.
- *
- * @param {Object[]} pData - list of platform objects
- * @param {string[]} pNames - platform names to search
- * @param {string} wName - weapon name to count
- * @returns {number}
- */
 function getSideColor(sideId, fallbackColor) {
     if (typeof SideConfig !== 'undefined' && typeof SideConfig.getColorForSide === 'function') {
         const color = SideConfig.getColorForSide(sideId);
@@ -37,6 +29,108 @@ function getSideLabelOrFallback(sideId, fallbackLabel) {
     return fallbackLabel || '';
 }
 
+
+function getFallbackRangeBand(record, minFieldNames, maxFieldNames) {
+    function firstDefined(fieldNames) {
+        for (var i = 0; i < fieldNames.length; i++) {
+            if (record && record[fieldNames[i]] !== undefined && record[fieldNames[i]] !== null && record[fieldNames[i]] !== '') {
+                return record[fieldNames[i]];
+            }
+        }
+        return undefined;
+    }
+
+    var min = Number(firstDefined(minFieldNames));
+    var max = Number(firstDefined(maxFieldNames));
+
+    if (!isFinite(min)) {
+        min = 0;
+    }
+
+    return {
+        min: min,
+        max: max,
+        isValid: isFinite(min) && isFinite(max) && min >= 0 && max >= 0 && min <= max
+    };
+}
+
+function getResultsWeaponRangeBand(weapon) {
+    if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.getWeaponRangeBand === 'function') {
+        return RangeUtils.getWeaponRangeBand(weapon);
+    }
+    return getFallbackRangeBand(weapon, ['weapon_min_range', 'min_range'], ['weapon_max_range', 'max_range', 'weapon_range']);
+}
+
+function getResultsSensorRangeBand(sensor) {
+    if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.getSensorRangeBand === 'function') {
+        return RangeUtils.getSensorRangeBand(sensor);
+    }
+    return getFallbackRangeBand(sensor, ['sensor_min_range', 'min_range'], ['sensor_max_range', 'max_range', 'sensor_range']);
+}
+
+function isResultsDistanceInRangeBand(distance, rangeBand) {
+    if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.isDistanceInRangeBand === 'function') {
+        return RangeUtils.isDistanceInRangeBand(distance, rangeBand);
+    }
+
+    var parsedDistance = Number(distance);
+    return isFinite(parsedDistance) &&
+        rangeBand &&
+        rangeBand.isValid &&
+        parsedDistance >= rangeBand.min &&
+        parsedDistance <= rangeBand.max;
+}
+
+function formatResultsRange(value) {
+    if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.formatRange === 'function') {
+        return RangeUtils.formatRange(value);
+    }
+    var parsed = Number(value);
+    return isFinite(parsed) ? parsed.toLocaleString() : 'Unknown';
+}
+
+function formatResultsRangeBand(rangeBand) {
+    if (typeof RangeUtils !== 'undefined' && typeof RangeUtils.formatRangeBand === 'function') {
+        return RangeUtils.formatRangeBand(rangeBand);
+    }
+    if (!rangeBand || !rangeBand.isValid) {
+        return 'Unknown';
+    }
+    return formatResultsRange(rangeBand.min) + ' - ' + formatResultsRange(rangeBand.max) + ' m';
+}
+
+function getDistanceBetweenPlatformsForResults(platformName, enemyPlatformName) {
+    var distanceKey1 = platformName + '---' + enemyPlatformName;
+    var distanceKey2 = enemyPlatformName + '---' + platformName;
+
+    if (distanceData[distanceKey1] !== undefined) {
+        return distanceData[distanceKey1];
+    }
+    return distanceData[distanceKey2];
+}
+
+function describeOutOfBandReason(distance, rangeBand) {
+    var parsedDistance = Number(distance);
+    if (!isFinite(parsedDistance) || !rangeBand || !rangeBand.isValid) {
+        return 'invalid distance or range band';
+    }
+    if (parsedDistance < rangeBand.min) {
+        return 'inside minimum range';
+    }
+    if (parsedDistance > rangeBand.max) {
+        return 'beyond maximum range';
+    }
+    return 'outside range band';
+}
+
+/**
+ * Sum the quantity of a particular weapon across a set of platforms.
+ *
+ * @param {Object[]} pData - list of platform objects
+ * @param {string[]} pNames - platform names to search
+ * @param {string} wName - weapon name to count
+ * @returns {number}
+ */
 function getTotalWeaponQuantity(pData, pNames, wName) {
     console.log("results.js >>> getTotalWeaponQuantity() entered");
     let totalQuantity = 0;
@@ -135,7 +229,7 @@ function processItems(itemList, itemType) {
                     }
                     console.log(`Found platform: ${platform.platform_name}`);
 
-                    var range;
+                    var rangeBand;
                     if (itemType === 'weapon') {
                         var weapon = platform.weapons.find(w => w.name.trim().toLowerCase() === itemName.trim().toLowerCase());
                         if (!weapon) {
@@ -149,9 +243,8 @@ function processItems(itemList, itemType) {
                             console.log(`Weapon info for "${weapon.name}" not found in weaponData.`);
                             return;
                         }
-                        console.log(`Weapon info found: Range = ${weaponInfo.weapon_range} meters`);
-
-                        range = weaponInfo.weapon_range;
+                        rangeBand = getResultsWeaponRangeBand(weaponInfo);
+                        console.log(`Weapon info found: Range band = ${formatResultsRangeBand(rangeBand)}`);
                     } else if (itemType === 'sensor') {
                         var sensorEquipped = platform.sensors && platform.sensors.some(s => s.trim().toLowerCase() === itemName.trim().toLowerCase());
                         if (!sensorEquipped) {
@@ -165,17 +258,19 @@ function processItems(itemList, itemType) {
                             console.log(`Sensor info for "${itemName}" not found in sensorData.`);
                             return;
                         }
-                        console.log(`Sensor info found: Range = ${sensorInfo.sensor_range} meters`);
-
-                        range = sensorInfo.sensor_range;
+                        rangeBand = getResultsSensorRangeBand(sensorInfo);
+                        console.log(`Sensor info found: Range band = ${formatResultsRangeBand(rangeBand)}`);
                     } else {
                         console.log(`Unknown itemType "${itemType}". Skipping platform "${platform.platform_name}".`);
                         return;
                     }
 
-                    var distanceKey1 = platform.platform_name + '---' + enemyPlatform.platform_name;
-                    var distanceKey2 = enemyPlatform.platform_name + '---' + platform.platform_name;
-                    var distance = distanceData[distanceKey1] || distanceData[distanceKey2];
+                    if (!rangeBand || !rangeBand.isValid) {
+                        console.log(`Invalid range band for ${itemType} "${itemName}" (${formatResultsRangeBand(rangeBand)}). Skipping platform "${platform.platform_name}".`);
+                        return;
+                    }
+
+                    var distance = getDistanceBetweenPlatformsForResults(platform.platform_name, enemyPlatform.platform_name);
 
                     if (distance === undefined) {
                         console.log(`Distance between "${platform.platform_name}" and "${enemyPlatform.platform_name}" not found.`);
@@ -184,8 +279,8 @@ function processItems(itemList, itemType) {
 
                     console.log(`Distance between "${platform.platform_name}" and "${enemyPlatform.platform_name}": ${distance} meters`);
 
-                    if (distance <= range) {
-                        console.log(`Enemy "${enemyPlatform.platform_name}" is within range (${distance} <= ${range}) of "${itemName}" from "${platform.platform_name}".`);
+                    if (isResultsDistanceInRangeBand(distance, rangeBand)) {
+                        console.log(`Enemy "${enemyPlatform.platform_name}" is within range band (${formatResultsRange(rangeBand.min)} <= ${formatResultsRange(distance)} <= ${formatResultsRange(rangeBand.max)} meters) of "${itemName}" from "${platform.platform_name}".`);
 
                         contributingPlatformsSet.add(platform.platform_name);
                         contributingPlatforms = Array.from(contributingPlatformsSet);
@@ -205,9 +300,9 @@ function processItems(itemList, itemType) {
                         isInRange = true;
                         inRangeCount++;
 
-                        console.log(`Enemy "${enemyPlatform.platform_name}" is within range of "${itemName}" from "${platform.platform_name}" at: ${distance} meters`);
+                        console.log(`Enemy "${enemyPlatform.platform_name}" is within range band of "${itemName}" from "${platform.platform_name}" at: ${formatResultsRange(distance)} meters`);
                     } else {
-                        console.log(`Enemy "${enemyPlatform.platform_name}" is out of range (${distance} > ${range}) of "${itemName}" from "${platform.platform_name}".`);
+                        console.log(`Enemy "${enemyPlatform.platform_name}" is out of range band (${formatResultsRange(distance)} m is ${describeOutOfBandReason(distance, rangeBand)}; valid band ${formatResultsRangeBand(rangeBand)}) of "${itemName}" from "${platform.platform_name}".`);
                     }
                 });
             });
@@ -215,8 +310,8 @@ function processItems(itemList, itemType) {
             var percentageInRange = totalEnemies > 0 ? (inRangeCount / totalEnemies) * 100 : 0;
             var percentageOutOfRange = 100 - percentageInRange;
 
-            console.log(`Percentage of enemies in range for ${itemType} ${itemName} in group ${group}: ${percentageInRange}%`);
-            console.log(`Percentage of enemies out of range for ${itemType} ${itemName} in group ${group}: ${percentageOutOfRange}%`);
+            console.log(`Percentage of enemies in range band for ${itemType} ${itemName} in group ${group}: ${percentageInRange}%`);
+            console.log(`Percentage of enemies out of range band for ${itemType} ${itemName} in group ${group}: ${percentageOutOfRange}%`);
 
             const selectedColor = getSideColor(selectedSide, '#36A2EB');
             const enemySideLabel = getSideLabelOrFallback(enemySide, 'Enemy');
@@ -288,7 +383,7 @@ function processItems(itemList, itemType) {
                         barPriority: numPlatsBarPriority
                     },
                     {
-                        barLabel: `${enemySideLabel} Platforms in WEZ`,
+                        barLabel: `${enemySideLabel} Platforms in WEZ / range band`,
                         barValue: wez,
                         barColor: wezBarColor,
                         barPriority: wezBarPriority
@@ -312,9 +407,9 @@ function processItems(itemList, itemType) {
                 console.log("results.js >>> processItems() >>> invalid chart-type");
             }
 
-            console.log(`\nMap of shooter platforms to in-range enemies for ${itemType} "${itemName}" and group "${group}":`);
+            console.log(`\nMap of shooter platforms to enemies within range band for ${itemType} "${itemName}" and group "${group}":`);
             platformToEnemiesMap.forEach(function(enemyList, shooterPlatform) {
-                console.log(`Shooter Platform: ${shooterPlatform} -> In-range Enemies: ${enemyList.join(', ')}`);
+                console.log(`Shooter Platform: ${shooterPlatform} -> In-range-band Enemies: ${enemyList.join(', ')}`);
             });
 
         });

--- a/results/js/legend.js
+++ b/results/js/legend.js
@@ -81,7 +81,7 @@ function createLegend(divId, legendType, side) {
     var enemySideColor = resolveSideColor(friendlySideId, '#4d94ff');
 
     if (legendType === 'Pie') {
-        // Row 1: 'Side' Circle | "Percent of Platforms in WEZ"
+        // Row 1: 'Side' Circle | "Percent of Platforms in WEZ / range band"
         var row1 = tbody.insertRow();
 
         var cell1 = row1.insertCell();
@@ -94,9 +94,9 @@ function createLegend(divId, legendType, side) {
         cell1.appendChild(sideCircle);
 
         var cell2 = row1.insertCell();
-        cell2.innerText = ` Percent of ${enemySideText} Platforms in WEZ`;
+        cell2.innerText = ` Percent of ${enemySideText} Platforms in WEZ / range band`;
 
-        // Row 2: Grey Circle | "Percent of Platforms outside of WEZ"
+        // Row 2: Grey Circle | "Percent of Platforms outside WEZ / range band"
         var row2 = tbody.insertRow();
 
         var cell3 = row2.insertCell();
@@ -113,7 +113,7 @@ function createLegend(divId, legendType, side) {
         row1.classList.add('legend-row');
         row2.classList.add('legend-row');
 
-        cell4.innerText = ` Percent of ${enemySideText} Platforms outside of WEZ`;
+        cell4.innerText = ` Percent of ${enemySideText} Platforms outside WEZ / range band`;
     } else if (legendType === 'Loadout') {
         // Row 1: Grey Bar | "Number of Red Platforms in the Group"
         var row1 = tbody.insertRow();
@@ -129,7 +129,7 @@ function createLegend(divId, legendType, side) {
         var cell2 = row1.insertCell();
         cell2.innerText = `Number of ${enemySideText} Platforms in the Group`;
 
-        // Row 2: 'enemySide' Bar | "Number of Red Platforms in the WEZ"
+        // Row 2: 'enemySide' Bar | "Number of platforms in the WEZ / range band"
         var row2 = tbody.insertRow();
 
         var cell3 = row2.insertCell();
@@ -141,7 +141,7 @@ function createLegend(divId, legendType, side) {
         cell3.appendChild(enemySide);
 
         var cell4 = row2.insertCell();
-        cell4.innerText = `Number of ${enemySideText} Platforms in the WEZ`;
+        cell4.innerText = `Number of ${enemySideText} Platforms in the WEZ / range band`;
 
         // Row 3: Yellow Bar | "Quantity of Available Weapons"
         var row3 = tbody.insertRow();


### PR DESCRIPTION
### Motivation
- Results coverage must evaluate whether a target lies inside a weapon/sensor min–max band (inclusive) instead of comparing distance to a single scalar max value.  This implements Phase 5 of the range-band rollout to make coverage charts and logs min/max-aware.  

### Description
- Added range-band helpers and fallbacks in `results/js/charts.js`: `getResultsWeaponRangeBand`, `getResultsSensorRangeBand`, `getFallbackRangeBand`, `isResultsDistanceInRangeBand`, `formatResultsRange`, `formatResultsRangeBand`, `getDistanceBetweenPlatformsForResults`, and `describeOutOfBandReason` to centralize band parsing, formatting, and legacy-field tolerance.  
- Replaced scalar checks with the band predicate `min <= distance <= max` in `processItems()` and added early skipping for invalid/missing bands, using `getResultsWeaponRangeBand` / `getResultsSensorRangeBand` so legacy `weapon_range` / `sensor_range` remain supported.  
- Centralized distance lookup to `getDistanceBetweenPlatformsForResults()` to avoid duplicated key logic and improved debug messages to explain whether an out-of-band target is `inside minimum range` or `beyond maximum range`.  
- Updated UI/legend text and chart bar labels so messaging explicitly refers to WEZ/coverage as a “range band” (changes in `results/js/legend.js` and label in `results/js/charts.js`).  

### Testing
- Syntax checks: ran `node --check results/js/charts.js && node --check results/js/legend.js && node --check js/range_utils.js` and they passed.  
- Functional smoke test: executed a Node VM test that ran `processItems()` with a sample weapon band (100–200 m) and enemy distances (too-close, in-band, too-far) and asserted the produced pie-chart percentages and contributing-platform lists; the smoke test passed (expected 60% in-band / 40% out-of-band and correct contributing enemies).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2987542ed4832aa7bc7bbb332dfae6)