### PR TITLE
Remove Ctrl-click range-ring toggle; add "Untoggle All" in range ring menu and remove map Clear Range Rings button

### DIFF
--- a/css/walt-menu-styles.css
+++ b/css/walt-menu-styles.css
@@ -284,7 +284,7 @@
   /* ============================================= */
   #clearSelectedButton {
     position: absolute;
-    bottom: 60px; /* Positioned above the Clear Range Rings button */
+    bottom: 10px;
     right: 10px;
     z-index: 1000;
     background-color: #ff6347; 
@@ -300,23 +300,6 @@
     background-color: #ff4500;
   }
   
-  #clearRangeRingsButton {
-    position: absolute;
-    bottom: 10px;
-    right: 10px;
-    z-index: 1000;
-    background-color: #ff6347; 
-    color: white;
-    border: none;
-    padding: 10px 20px;
-    cursor: pointer;
-    font-size: 14px;
-    border-radius: 5px;
-  }
-  
-  #clearRangeRingsButton:hover {
-    background-color: #ff4500; /* Darker shade on hover */
-  }
   
   /* ============================================= */
   /* Button Container & Custom Buttons             */

--- a/index.html
+++ b/index.html
@@ -54,10 +54,6 @@
       <button id="clearSelectedButton">
         Clear Markers
       </button>
-      <!-- Clear Range Rings Button -->
-      <button id="clearRangeRingsButton">
-        Clear Range Rings
-      </button>
     </div>
 
     <!------------------------------------------->

--- a/js/range_rings/range_ring_config.js
+++ b/js/range_rings/range_ring_config.js
@@ -7,6 +7,7 @@ var RangeRingConfig = (function() {
         var content = `
             <div>
                 <button id="toggleAllCheckboxes">Toggle All</button>
+                <button id="untoggleAllRangeRingsButton">Untoggle All</button>
                 <button id="editRangeRingStyleButton">Edit Style</button>
                 <table id="rangeRingTable" class="display">
                     <thead>
@@ -87,6 +88,11 @@ var RangeRingConfig = (function() {
             });
 
             RangeRingLogic.drawRangeRings();
+        });
+
+        $('#untoggleAllRangeRingsButton').on('click', function() {
+            rangeRingDataTable.rows().nodes().to$().find('.range-toggle').prop('checked', false);
+            RangeRingLogic.clearAllRangeRings();
         });
 
         $('#editRangeRingStyleButton').on('click', function() {

--- a/js/range_rings/range_ring_logic.js
+++ b/js/range_rings/range_ring_logic.js
@@ -109,23 +109,6 @@ var RangeRingLogic = (function() {
     return parsed === null ? 'Unknown' : parsed.toLocaleString();
   }
 
-  function drawRangeRingForPlatform(platformName) {
-    if (!platformName) { return; }
-    var rangeRings = RangeRingStorage.getAllRangeRings();
-    if (!Array.isArray(rangeRings)) { return; }
-
-    var matchingRangeRings = rangeRings.filter(function(rangeRing) {
-      return rangeRing.platform_name === platformName;
-    });
-    if (!matchingRangeRings.length) { return; }
-
-    var enableRings = matchingRangeRings.some(function(rangeRing) { return rangeRing.toggled !== 1; });
-    var newToggleValue = enableRings ? 1 : 0;
-    matchingRangeRings.forEach(function(rangeRing) { rangeRing.toggled = newToggleValue; });
-
-    drawRangeRings();
-  }
-
   function clearRangeRings() {
     var map = View.getMap();
     rangeRingLayers.forEach(function(layer) { map.removeLayer(layer); });
@@ -134,8 +117,7 @@ var RangeRingLogic = (function() {
 
   function clearAllRangeRings() {
     RangeRingStorage.setAllRangeRingToggleStates(0);
-    clearRangeRings();
-    updateRangeRingConfigCheckboxes();
+    drawRangeRings();
   }
 
   function updateRangeRingConfigCheckboxes() {
@@ -217,7 +199,6 @@ var RangeRingLogic = (function() {
 
   return {
     drawRangeRings: drawRangeRings,
-    drawRangeRingForPlatform: drawRangeRingForPlatform,
     clearRangeRings: clearRangeRings,
     clearAllRangeRings: clearAllRangeRings,
     applyStyleToToggledRangeRings: applyStyleToToggledRangeRings,

--- a/js/table_controller.js
+++ b/js/table_controller.js
@@ -635,20 +635,6 @@ var TableController = (function() {
                 }
             }
         });
-
-        // Handle ctrl-click on table rows
-        $('#platformTable tbody').on('click', 'tr', function(event) {
-            if (event.ctrlKey) {
-                var rowData = dataTableInstance.row(this).data();
-                var platform = PlatformModel.getPlatformData().find(function(p) {
-                    return p.platform_name === rowData.platform_name;
-                });
-                if (platform) {
-                    var platformName = platform.platform_name;
-                    RangeRingLogic.drawRangeRingForPlatform(platformName);
-                }
-            }
-        });
     }
 
     // Function to redraw the table with the latest platform data

--- a/js/view.js
+++ b/js/view.js
@@ -112,11 +112,6 @@ var View = (function() {
             }
         });
 
-        // Add Clear Range Rings button functionality
-        document.getElementById('clearRangeRingsButton').addEventListener('click', function() {
-            RangeRingLogic.clearAllRangeRings();
-        });
-
         // Add Export Laydown button functionality
         document.getElementById('exportLaydownButton').addEventListener('click', function() {
             LaydownExporter.exportLaydown();
@@ -223,16 +218,6 @@ var View = (function() {
                     if (platform) {
                         var platformName = platform.platform_name;
                         addPlatformToSelected(platformName);
-                    }
-                }
-            });
-
-            // Handle ctrl-click event for seeing range rings
-            marker.on('mousedown', function(event) {
-                if (event.originalEvent.ctrlKey) { // Access the native event for ctrlKey
-                    if (platform) {
-                        var platformName = platform.platform_name;
-                        RangeRingLogic.drawRangeRingForPlatform(platformName);
                     }
                 }
             });


### PR DESCRIPTION
### Motivation

- Users should no longer be able to Ctrl+Left-click platforms (map markers or table rows) to toggle or show range rings, centralizing range-ring control in the Range Ring menu.
- The map-level "Clear Range Rings" button is being removed to simplify the map UI and push global toggling behavior into the configuration dialog.
- Provide an explicit "Untoggle All" control in the Range Ring menu that untoggles all rings and refreshes the map.

### Description

- Removed the map-level Clear Range Rings button from `index.html` and removed its CSS rules so the map UI no longer shows that button, and repositioned the remaining Clear Markers button via `css/walt-menu-styles.css` by adjusting `#clearSelectedButton` bottom placement.
- Eliminated the Ctrl-click-to-toggle behavior by removing the event handlers that called `RangeRingLogic.drawRangeRingForPlatform` from `js/view.js` (marker ctrl-click) and `js/table_controller.js` (table row ctrl-click), and removed the now-unused exported `drawRangeRingForPlatform` from `js/range_rings/range_ring_logic.js`.
- Added an `Untoggle All` button to the Range Ring dialog in `js/range_rings/range_ring_config.js` with id `untoggleAllRangeRingsButton` that unchecks all DataTable page controls and calls `RangeRingLogic.clearAllRangeRings()` to refresh the map.
- Updated `RangeRingLogic.clearAllRangeRings()` in `js/range_rings/range_ring_logic.js` to set all stored toggles off and call `drawRangeRings()` so the map is refreshed to remove visible rings (instead of directly manipulating layers and checkboxes), and kept `updateRangeRingConfigCheckboxes()` behavior intact via redraw.

### Testing

- Ran static JS syntax checks with `node --check` against `js/range_rings/range_ring_logic.js`, `js/range_rings/range_ring_config.js`, `js/view.js`, and `js/table_controller.js`, and they succeeded.
- Performed a repository grep to verify removal/addition points (no remaining `drawRangeRingForPlatform` or `clearRangeRingsButton` usages besides the intended `clearAllRangeRings` caller), which returned expected results.
- Ran `git diff --check` to ensure no whitespace or diff errors were produced, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ab9c869b0832ab219f0dc9e09430d)