### PR TITLE
Simplify weapon lethality dialog CSS layout and strip component-specific visuals

### DIFF
--- a/css/weapon-lethality-styles.css
+++ b/css/weapon-lethality-styles.css
@@ -4,54 +4,29 @@
 /* Weapon Lethality Dialog Styles               */
 /* ============================================= */
 .weapon-lethality-dialog {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
+    display: block;
 }
 
 .weapon-lethality-controls {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
-    align-items: flex-end;
+    margin-bottom: 10px;
 }
 
 .weapon-lethality-control {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
+    display: inline-block;
     min-width: 160px;
+    margin-right: 10px;
+    vertical-align: bottom;
 }
 
 .weapon-lethality-control label {
-    font-weight: 600;
-    color: #1f2937;
-}
-
-.weapon-lethality-control select,
-.weapon-lethality-control input[type="number"] {
-    padding: 6px 8px;
-    border: 1px solid #d1d5db;
-    border-radius: 4px;
-    font-size: 0.95rem;
+    display: block;
 }
 
 .weapon-lethality-control--button {
-    align-self: flex-end;
-}
-
-.weapon-lethality-control--button button {
-    padding: 8px 16px;
-    background-color: #2563eb;
-    color: #fff;
-    border: none;
-    border-radius: 4px;
-    font-weight: 600;
-    cursor: pointer;
+    min-width: auto;
 }
 
 .weapon-lethality-control--button button:disabled {
-    background-color: #9ca3af;
     cursor: not-allowed;
 }
 
@@ -59,45 +34,13 @@
 .weapon-lethality-table input[type="number"] {
     width: 100%;
     box-sizing: border-box;
-    padding: 6px 8px;
-    border: 1px solid #d1d5db;
-    border-radius: 4px;
 }
 
 .weapon-lethality-table .actions-cell {
     text-align: center;
 }
 
-.weapon-lethality-table .lethality-delete-button {
-    padding: 6px 12px;
-    background-color: #dc2626;
-    color: #fff;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    font-weight: 600;
-}
-
-.weapon-lethality-table .lethality-delete-button:hover {
-    background-color: #b91c1c;
-}
-
 .weapon-lethality-footer {
-    display: flex;
-    justify-content: flex-end;
-    gap: 12px;
-}
-
-.weapon-lethality-footer button {
-    padding: 8px 16px;
-    background-color: #10b981;
-    color: #fff;
-    border: none;
-    border-radius: 4px;
-    font-weight: 600;
-    cursor: pointer;
-}
-
-.weapon-lethality-footer button:hover {
-    background-color: #059669;
+    margin-top: 10px;
+    text-align: right;
 }


### PR DESCRIPTION
### Motivation
- Reduce complex component-level layout rules and visual overrides to make the dialog integrate better with the global UI system.
- Remove hard-coded paddings, borders, colors, and hover rules so base styles or a design system can control visual appearance.

### Description
- Convert `.weapon-lethality-dialog` from a `flex` column layout to a simpler `block` layout and adjust control container spacing.
- Change `.weapon-lethality-control` to `inline-block` with right margin and vertical alignment for compact horizontal placement.
- Remove custom styling for `select`, `input[type="number"]`, buttons, delete button, and many hover/background/border rules, leaving inputs full-width inside the table and simplified footer alignment.
- Preserve layout-related sizing like `min-width` for controls and `width: 100%` for table inputs while dropping component-specific color/padding/border styles.

### Testing
- Ran `stylelint` to validate CSS syntax and it completed without errors.
- Performed a local build (`npm run build`) to ensure assets compile, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ac465da48832aae1ea26c2b7a46e5)