### PR TITLE
Add runtime laydown loader and UI to switch input folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,24 @@ and any icon/color overrides you need:
 Scripts that render dropdowns, map icons, range rings, or results views consume this shared
 configuration. If a platform, weapon, or sensor references a side that is not defined, the UI falls
 back to the configured default icon and a neutral color so undefined sides are still displayed.
+
+## Loading an alternate laydown
+
+The default baseline scenario remains the repository `input/` folder. Opening `index.html` without
+selecting anything still loads the six checked-in files from that folder.
+
+To switch to another laydown while the application is running, click **Load Laydown** above the
+platform table and select a folder that contains all six required JavaScript files:
+
+- `labels.js`
+- `platform_details.js`
+- `range_ring_style_templates.js`
+- `sensor_details.js`
+- `weapon_details.js`
+- `weapon_lethality_details.js`
+
+After the folder is selected, WALT validates that all six files are present, reloads the platform,
+weapon, weapon lethality, sensor, label, range-ring, distance, table, and map data, and keeps the
+same page open. The selected folder's files use the same variable names as the default `input/`
+files.
+

--- a/css/walt-menu-styles.css
+++ b/css/walt-menu-styles.css
@@ -63,6 +63,10 @@
     gap: 6px;
 }
 
+#platformTableContainer .laydown-folder-input {
+    display: none;
+}
+
 #platformTableContainer .column-toggle-button {
     padding: 6px 10px;
     font-size: 0.85rem;

--- a/index.html
+++ b/index.html
@@ -68,6 +68,22 @@
           <div class="platform-table-toolbar-actions">
             <button
               type="button"
+              id="loadLaydownButton"
+              class="column-toggle-button"
+            >
+              Load Laydown
+            </button>
+            <input
+              type="file"
+              id="loadLaydownInput"
+              class="laydown-folder-input"
+              aria-label="Select laydown input folder"
+              webkitdirectory
+              directory
+              multiple
+            >
+            <button
+              type="button"
               id="iconsButton"
               class="column-toggle-button"
               aria-haspopup="true"
@@ -158,6 +174,7 @@
   <script src="js/distance_storage.js"></script>
   <script src="js/labels/label_storage.js"></script>
   <script src="js/export_laydown.js"></script>
+  <script src="js/laydown_loader.js"></script>
   <script src="js/map_tools/map_tools_menu.js"></script>
   <script src="js/menu/main_menu_layout_config.js"></script>
   <script src="js/menu/main_menu_button_layout.js"></script>

--- a/init.js
+++ b/init.js
@@ -34,5 +34,6 @@ View.renderPlatforms(); // Add platforms to the map from PlatformModel and add e
 SelectionController.init(); // Initialize the selection controller (allows for platforms to be selected and dragged around)
 PlatformCopyController.init(); // Enable copy-paste workflows for selected platforms
 PlatformDeletionController.init(); // Enable deletion of selected platforms via the Delete key
+LaydownLoader.init(); // Enable loading a different laydown input folder at runtime
 
 

--- a/js/labels/label_storage.js
+++ b/js/labels/label_storage.js
@@ -4,6 +4,7 @@ var LabelStorage = (function() {
     var currentId = 0; // To generate unique IDs
 
     function loadInitialData(initialLabelData) {
+        currentId = 0;
         labelData = initialLabelData.map(function(item) {
             if (item.label_id >= currentId) {
                 currentId = item.label_id + 1;

--- a/js/laydown_loader.js
+++ b/js/laydown_loader.js
@@ -1,0 +1,221 @@
+// laydown_loader.js
+var LaydownLoader = (function() {
+    var REQUIRED_FILES = [
+        {
+            fileName: 'platform_details.js',
+            variableName: 'PLATFORM_DATA',
+            globalName: 'PLATFORM_DATA'
+        },
+        {
+            fileName: 'weapon_details.js',
+            variableName: 'WEAPON_DATA',
+            globalName: 'WEAPON_DATA'
+        },
+        {
+            fileName: 'weapon_lethality_details.js',
+            variableName: 'WEAPON_LETHALITY_DATA',
+            globalName: 'WEAPON_LETHALITY_DATA'
+        },
+        {
+            fileName: 'sensor_details.js',
+            variableName: 'SENSOR_DATA',
+            globalName: 'SENSOR_DATA'
+        },
+        {
+            fileName: 'labels.js',
+            variableName: 'LABEL_DATA',
+            globalName: 'LABEL_DATA'
+        },
+        {
+            fileName: 'range_ring_style_templates.js',
+            variableName: 'range_ring_style_templates',
+            globalName: 'range_ring_style_templates'
+        }
+    ];
+
+    function init() {
+        var button = document.getElementById('loadLaydownButton');
+        var input = document.getElementById('loadLaydownInput');
+
+        if (!button || !input) {
+            return;
+        }
+
+        button.addEventListener('click', function() {
+            input.value = '';
+            input.click();
+        });
+
+        input.addEventListener('change', function(event) {
+            var files = Array.prototype.slice.call(event.target.files || []);
+            if (!files.length) {
+                return;
+            }
+
+            loadFromFileList(files)
+                .then(function(summary) {
+                    alert('Loaded laydown from "' + summary.folderName + '".');
+                })
+                .catch(function(error) {
+                    console.error('laydown_loader.js: failed to load laydown', error);
+                    alert(error.message || 'Unable to load the selected laydown folder.');
+                });
+        });
+    }
+
+    function loadFromFileList(files) {
+        return new Promise(function(resolve, reject) {
+            var selectedFiles;
+
+            try {
+                selectedFiles = selectRequiredFiles(files);
+            } catch (error) {
+                reject(error);
+                return;
+            }
+
+            Promise.all(REQUIRED_FILES.map(function(requirement) {
+                return readScenarioFile(selectedFiles[requirement.fileName], requirement);
+            })).then(function(results) {
+                var laydownData = {};
+                results.forEach(function(result) {
+                    laydownData[result.requirement.globalName] = result.value;
+                });
+
+                applyLaydownData(laydownData);
+                resolve({ folderName: getFolderName(selectedFiles) });
+            }).catch(reject);
+        });
+    }
+
+    function selectRequiredFiles(files) {
+        var filesByName = {};
+        files.forEach(function(file) {
+            if (!file || !file.name) {
+                return;
+            }
+
+            if (!filesByName[file.name] || getPathDepth(file) < getPathDepth(filesByName[file.name])) {
+                filesByName[file.name] = file;
+            }
+        });
+
+        var missingFiles = REQUIRED_FILES.filter(function(requirement) {
+            return !filesByName[requirement.fileName];
+        }).map(function(requirement) {
+            return requirement.fileName;
+        });
+
+        if (missingFiles.length) {
+            throw new Error('The selected folder is missing required laydown file(s): ' + missingFiles.join(', '));
+        }
+
+        return filesByName;
+    }
+
+    function getPathDepth(file) {
+        var relativePath = file.webkitRelativePath || file.name || '';
+        return relativePath.split('/').filter(Boolean).length;
+    }
+
+    function getFolderName(selectedFiles) {
+        var firstRequirement = REQUIRED_FILES[0];
+        var firstFile = selectedFiles[firstRequirement.fileName];
+        var relativePath = firstFile && firstFile.webkitRelativePath ? firstFile.webkitRelativePath : '';
+        var parts = relativePath.split('/').filter(Boolean);
+        return parts.length > 1 ? parts[0] : 'selected folder';
+    }
+
+    function readScenarioFile(file, requirement) {
+        return file.text().then(function(source) {
+            return {
+                requirement: requirement,
+                value: extractVariable(source, requirement)
+            };
+        });
+    }
+
+    function extractVariable(source, requirement) {
+        var extractor;
+        var value;
+
+        try {
+            extractor = new Function(
+                source + '\nreturn (typeof ' + requirement.variableName + ' !== "undefined") ? ' + requirement.variableName + ' : undefined;'
+            );
+            value = extractor();
+        } catch (error) {
+            throw new Error('Unable to evaluate ' + requirement.fileName + ': ' + error.message);
+        }
+
+        if (!Array.isArray(value)) {
+            throw new Error(requirement.fileName + ' must define an array named ' + requirement.variableName + '.');
+        }
+
+        return cloneArray(value);
+    }
+
+    function cloneArray(value) {
+        if (typeof structuredClone === 'function') {
+            return structuredClone(value);
+        }
+        return JSON.parse(JSON.stringify(value));
+    }
+
+    function applyLaydownData(laydownData) {
+        window.PLATFORM_DATA = laydownData.PLATFORM_DATA;
+        window.WEAPON_DATA = laydownData.WEAPON_DATA;
+        window.WEAPON_LETHALITY_DATA = laydownData.WEAPON_LETHALITY_DATA;
+        window.SENSOR_DATA = laydownData.SENSOR_DATA;
+        window.LABEL_DATA = laydownData.LABEL_DATA;
+        window.range_ring_style_templates = laydownData.range_ring_style_templates;
+
+        closeOpenDialogs();
+
+        PlatformModel.loadInitialData(window.PLATFORM_DATA);
+        WeaponStorage.loadInitialData(window.WEAPON_DATA);
+        WeaponLethalityStorage.loadInitialData(window.WEAPON_LETHALITY_DATA);
+        SensorStorage.loadInitialData(window.SENSOR_DATA);
+        LabelStorage.loadInitialData(window.LABEL_DATA);
+        DistanceStorage.refreshDistanceData();
+        RangeRingStorage.init();
+
+        if (typeof SelectionController !== 'undefined') {
+            SelectionController.clearSelectedMarkers();
+        }
+        if (typeof TableController !== 'undefined') {
+            TableController.redrawTable();
+        }
+        if (typeof View !== 'undefined') {
+            View.renderPlatforms();
+        }
+        if (typeof LabelController !== 'undefined') {
+            LabelController.renderLabels();
+        }
+        if (typeof View !== 'undefined' && typeof View.updateAll === 'function') {
+            View.updateAll();
+        }
+    }
+
+    function closeOpenDialogs() {
+        if (typeof $ === 'undefined' || !$.fn || !$.fn.dialog) {
+            return;
+        }
+
+        $('.ui-dialog-content').each(function() {
+            var $dialog = $(this);
+            if ($dialog.hasClass('ui-dialog-content')) {
+                try {
+                    $dialog.dialog('close');
+                } catch (error) {
+                    console.warn('laydown_loader.js: unable to close dialog', error);
+                }
+            }
+        });
+    }
+
+    return {
+        init: init,
+        loadFromFileList: loadFromFileList
+    };
+})();


### PR DESCRIPTION
### Motivation
- Provide a way to load an alternate laydown (the six input JS files) at runtime without reloading the page. 
- Ensure label IDs are reinitialized when new label data is loaded so newly added labels get unique IDs.

### Description
- Add a new `js/laydown_loader.js` module that validates a selected folder contains the six required files, reads and evaluates them, clones their arrays, applies them to the global variables, and refreshes storage and UI state. 
- Add a `Load Laydown` button and a hidden directory file input to `index.html`, and include the new loader script, and initialize it from `init.js` via `LaydownLoader.init()`. 
- Update `README.md` with documentation describing how to load an alternate laydown folder and listing the required files. 
- Add CSS rule to hide the folder input in `css/walt-menu-styles.css`, and change `js/labels/label_storage.js` to reset `currentId` when loading initial label data.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ae80bed74832a8b9571c51ff7c3e5)