### PR TITLE
Shrink range inputs in configuration dialogs

### DIFF
--- a/css/walt-menu-styles.css
+++ b/css/walt-menu-styles.css
@@ -405,3 +405,23 @@
 .ui-dialog-content {
     padding: 20px;
 }
+
+
+/* ============================================= */
+/* Weapon and Sensor Configuration Range Inputs  */
+/* ============================================= */
+#weaponInfoDialog .weapon-min-range,
+#weaponInfoDialog .weapon-max-range,
+#weaponInfoDialog #newWeaponMinRange,
+#weaponInfoDialog #newWeaponMaxRange,
+#sensorInfoDialog .sensor-min-range,
+#sensorInfoDialog .sensor-max-range,
+#sensorInfoDialog #newSensorMinRange,
+#sensorInfoDialog #newSensorMaxRange,
+#addWeaponDialogContent #newWeaponMinRange,
+#addWeaponDialogContent #newWeaponMaxRange,
+#addSensorDialogContent #newSensorMinRange,
+#addSensorDialogContent #newSensorMaxRange {
+    box-sizing: border-box;
+    width: 50% !important;
+}


### PR DESCRIPTION
### Motivation
- The minimum and maximum range number inputs in the Weapon Configuration and Sensor Configuration dialogs (including the add-new dialogs) were visually too wide and needed to be reduced to improve layout and alignment.

### Description
- Added a targeted CSS block to `css/walt-menu-styles.css` that sets `box-sizing: border-box;` and `width: 50% !important;` for the weapon and sensor min/max inputs (including `#newWeaponMinRange`, `#newWeaponMaxRange`, `#newSensorMinRange`, `#newSensorMaxRange` and the per-row `.weapon-min-range`, `.weapon-max-range`, `.sensor-min-range`, `.sensor-max-range`).

### Testing
- Ran `git diff --check` to verify no whitespace or diff issues and it completed cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bfcda56fc832abd543c1cf4db0290)